### PR TITLE
[BUG] Fix Groß-/Kleinschreibung in Bib-File

### DIFF
--- a/pm.bib
+++ b/pm.bib
@@ -4,6 +4,7 @@
   url     = {https://www.atlassian.com/git/tutorials},
   urldate = {2022-03-03},
   year    = {2022},
+  langid  = {en}
 }
 
 @Online{AtlassianHelloWorld,
@@ -12,6 +13,7 @@
   url     = {https://www.atlassian.com/blog/wp-content/uploads/HelloWorldEbook.pdf},
   urldate = {2020-04-14},
   year    = {2022},
+  langid  = {en}
 }
 
 @Book{Beck2014,
@@ -20,6 +22,7 @@
   isbn      = {978-0-3211-4653-3},
   publisher = {Addison-Wesley},
   year      = {2014},
+  langid    = {en}
 }
 
 @Book{Bloch2011,
@@ -30,6 +33,7 @@
   note      = {als Semesterapparat in FH-Bibliothek in Minden verfügbar},
   publisher = {Addison-Wesley},
   year      = {2011},
+  langid    = {en}
 }
 
 @Book{Bloch2018,
@@ -39,6 +43,7 @@
   isbn      = {978-0-13-468599-1},
   publisher = {Addison-Wesley},
   year      = {2018},
+  langid    = {en}
 }
 
 @Book{Boles2008,
@@ -49,6 +54,7 @@
   year      = {2008},
   url       = {http://www.boles.de/hamster/band3.html},
   urldate   = {2022-06-09},
+  langid    = {de}
 }
 
 @Book{Chacon2014,
@@ -60,6 +66,7 @@
   url       = {https://git-scm.com/book/en/v2},
   urldate   = {2020-04-14},
   year      = {2014},
+  langid    = {en}
 }
 
 @Book{Deitel2012,
@@ -70,6 +77,7 @@
   note      = {Hauptliteratur; als Lehrbuch in FH-Bibliothek in Minden verfügbar},
   publisher = {Prentice Hall},
   year      = {2012},
+  langid    = {en}
 }
 
 @InProceedings{Dietz2018,
@@ -81,6 +89,7 @@
   url          = {http://ceur-ws.org/Vol-2066/isee2018paper06.pdf},
   urldate      = {2020-04-14},
   year         = {2018},
+  langid       = {en}
 }
 
 @Book{DockerInAction,
@@ -89,6 +98,7 @@
   isbn      = {978-1-6172-9476-1},
   publisher = {Manning Publications},
   year      = {2019},
+  langid    = {en}
 }
 
 @Book{DockerInPractice,
@@ -97,6 +107,7 @@
   isbn      = {978-1-6172-9480-8},
   publisher = {Manning Publications},
   year      = {2019},
+  langid    = {en}
 }
 
 @Book{Eckel2007,
@@ -106,6 +117,7 @@
   isbn      = {978-0-1318-7248-6},
   publisher = {Prentice Hall},
   year      = {2007},
+  langid    = {en}
 }
 
 @Book{Eilebrecht2013,
@@ -114,6 +126,7 @@
   isbn      = {978-3-6423-4718-4},
   publisher = {Springer},
   year      = {2013},
+  langid    = {de}
 }
 
 @Online{fernunihagenJunit,
@@ -123,6 +136,7 @@
   note         = {offline im März 2022, aber noch in Google Results},
   organization = {Fernuniversität in Hagen},
   urldate      = {2020-04-14},
+  langid       = {de}
 }
 
 @Book{Fowler2011,
@@ -132,6 +146,7 @@
   note      = {DER Klassiker! Jeder Entwickler sollte dieses Buch gelesen haben!},
   publisher = {Addison-Wesley},
   year      = {2011},
+  langid    = {en}
 }
 
 @Book{Gamma2011,
@@ -140,6 +155,7 @@
   isbn      = {978-0-2016-3361-0},
   publisher = {Addison-Wesley},
   year      = {2011},
+  langid    = {en}
 }
 
 @Online{GitCheatSheet,
@@ -148,6 +164,7 @@
   url     = {https://training.github.com/},
   urldate = {2022-03-03},
   year    = {2022},
+  langid  = {en}
 }
 
 @Online{GitFlow,
@@ -156,14 +173,16 @@
   url     = {https://nvie.com/posts/a-successful-git-branching-model/},
   urldate = {2022-03-07},
   year    = {2010},
+  langid  = {en}
 }
 
 @Online{GitHubCI,
   author  = {{GitHub Inc.}},
-  title   = {{Dokumentation GitHub CI}},
+  title   = {{Documentation GitHub CI}},
   url     = {https://resources.github.com/ci-cd/},
   urldate = {2022-03-10},
   year    = {2022},
+  langid  = {en}
 }
 
 @Online{GitHubFlow,
@@ -172,6 +191,7 @@
   url     = {https://githubflow.github.io/},
   urldate = {2022-03-07},
   year    = {2013},
+  langid  = {en}
 }
 
 @Online{GitHubFlowGH,
@@ -180,12 +200,14 @@
   url     = {https://docs.github.com/en/get-started/quickstart/github-flow},
   urldate = {2022-03-07},
   year    = {2022},
+  langid  = {en}
 }
 
 @Online{GitlabCI,
-  title   = {{Dokumentation Gitlab CI}},
+  title   = {{Documentation Gitlab CI}},
   url     = {http://git03-ifm-min.ad.fh-bielefeld.de/help/ci/},
   urldate = {2022-03-10},
+  langid  = {en}
 }
 
 @Online{googlestyleguide,
@@ -194,6 +216,7 @@
   url     = {https://google.github.io/styleguide/javaguide.html},
   urldate = {2022-03-10},
   year    = {2022},
+  langid  = {en}
 }
 
 @Online{Gradle,
@@ -202,6 +225,7 @@
   url     = {https://gradle.org/},
   urldate = {2022-03-10},
   year    = {2022},
+  langid  = {en}
 }
 
 @Book{Harrer2018,
@@ -210,6 +234,7 @@
   isbn      = {978-1-68050-287-9},
   publisher = {The Pragmatic Bookshelf},
   year      = {2018},
+  langid    = {en}
 }
 
 @Book{Inden2013,
@@ -219,6 +244,7 @@
   isbn      = {978-3-8649-1245-0},
   publisher = {dpunkt.verlag},
   year      = {2013},
+  langid    = {de}
 }
 
 @Online{Java-SE-Tutorial,
@@ -228,6 +254,7 @@
   note    = {JDK 8},
   urldate = {2022-03-09},
   year    = {2022},
+  langid  = {en}
 }
 
 @Online{JDK-Doc,
@@ -237,6 +264,7 @@
   note    = {JDK 17},
   urldate = {2022-03-09},
   year    = {2022},
+  langid  = {en}
 }
 
 @Book{Juneau2017,
@@ -246,6 +274,7 @@
   isbn      = {978-1-4842-1976-8},
   publisher = {Apress},
   year      = {2017},
+  langid    = {en}
 }
 
 @Online{junit4,
@@ -254,6 +283,7 @@
   url     = {https://junit.org/},
   urldate = {2022-03-10},
   year    = {2022},
+  langid  = {en}
 }
 
 @Book{Kleuker2013,
@@ -264,6 +294,7 @@
   note      = {Hauptliteratur},
   publisher = {Springer Fachmedien Wiesbaden},
   year      = {2013},
+  langid    = {de}
 }
 
 @Book{Kleuker2018,
@@ -273,6 +304,7 @@
   isbn      = {978-3-658-19969-2},
   publisher = {Springer Vieweg},
   year      = {2018},
+  langid    = {de}
 }
 
 @Book{Kleuker2019,
@@ -283,6 +315,7 @@
   note      = {Hauptliteratur},
   publisher = {Springer Vieweg},
   year      = {2019},
+  langid    = {de}
 }
 
 @Book{Krueger2009,
@@ -291,6 +324,7 @@
   isbn      = {978-3-8273-2874-8},
   publisher = {Addison-Wesley},
   year      = {2009},
+  langid    = {de}
 }
 
 @Online{LernJava,
@@ -299,6 +333,7 @@
   url     = {https://dev.java/learn/},
   urldate = {2022-03-09},
   year    = {2022},
+  langid  = {en}
 }
 
 @Book{Martin2009,
@@ -308,6 +343,7 @@
   note      = {DER Klassiker! Jeder Entwickler sollte dieses Buch gelesen haben!},
   publisher = {mitp},
   year      = {2009},
+  langid    = {en}
 }
 
 @Online{Mockito,
@@ -316,6 +352,7 @@
   url     = {https://github.com/mockito/mockito},
   urldate = {2022-04-29},
   year    = {2022},
+  langid  = {en}
 }
 
 @Book{Nystrom2014,
@@ -326,6 +363,7 @@
   year      = {2014},
   url       = {https://github.com/munificent/game-programming-patterns},
   urldate   = {2022-04-28},
+  langid    = {en}
 }
 
 @Book{Oestereich2012,
@@ -336,6 +374,7 @@
   url       = {https://www.oose.de/nuetzliches/uml-unified-modeling-language/},
   urldate   = {2020-04-14},
   year      = {2012},
+  langid    = {de}
 }
 
 @Book{Ogihar2018,
@@ -345,6 +384,7 @@
   isbn      = {978-3-319-89491-1},
   publisher = {Springer},
   year      = {2018},
+  langid    = {en}
 }
 
 @Book{Osherove2014,
@@ -353,6 +393,7 @@
   isbn      = {978-1-6172-9089-3},
   publisher = {Manning},
   year      = {2014},
+  langid    = {en}
 }
 
 @Book{Passig2013,
@@ -361,6 +402,7 @@
   isbn      = {978-3-89721-567-2},
   publisher = {O'Reilly},
   year      = {2013},
+  langid    = {de}
 }
 
 @Online{RefactoringGuru,
@@ -369,6 +411,7 @@
   url     = {https://refactoring.guru/refactoring/techniques},
   urldate = {2020-03-28},
   year    = {2022},
+  langid  = {en}
 }
 
 @Book{Spillner2012,
@@ -378,6 +421,7 @@
   isbn      = {978-3-86490-024-2},
   publisher = {dpunkt},
   year      = {2012},
+  langid    = {de}
 }
 
 @Online{SunMicrosystems1997,
@@ -386,6 +430,7 @@
   url     = {https://www.oracle.com/technetwork/java/codeconventions-150003.pdf},
   urldate = {2020-04-14},
   year    = {1997},
+  langid  = {en}
 }
 
 @Book{Ullenboom2021,
@@ -397,6 +442,7 @@
   url       = {https://openbook.rheinwerk-verlag.de/javainsel/index.html},
   urldate   = {2022-03-09},
   year      = {2021},
+  langid    = {de}
 }
 
 @Online{UML25,
@@ -405,6 +451,7 @@
   url     = {https://www.omg.org/spec/UML/2.5.1/PDF},
   urldate = {2020-04-14},
   year    = {2017},
+  langid  = {en}
 }
 
 @Book{Urma2014,
@@ -413,6 +460,7 @@
   isbn      = {978-1-6172-9199-9},
   publisher = {Manning Publications},
   year      = {2014},
+  langid    = {en}
 }
 
 @Online{vogellaJUnit,
@@ -421,4 +469,5 @@
   url     = {https://www.vogella.com/tutorials/JUnit/article.html},
   urldate = {2022-03-10},
   year    = {2021},
+  langid  = {en}
 }


### PR DESCRIPTION
Füge den Eintrag `langid = {de}` bzw. `langid = {en}` zu jedem Bibtex-Eintrag hinzu. Dadurch wird bei der Konvertierung mit Pandoc von Bibtex nach YAML als Basis für Hugo die korrekte Schreibweise des Titels behalten. 

Man kann den Titel auch mit doppelten geschweiften Klammern schützen, aber sobald eine gemischte Schreibweise vorliegt, wird Pandoc im YAML ein `[...]{.nocase}` um den Titel wrappen, was Hugo nicht versteht.


fixes #58 
