### PR TITLE
[VL] Fix landing pages

### DIFF
--- a/markdown/_index.md
+++ b/markdown/_index.md
@@ -1,7 +1,6 @@
 ---
 archetype: "home"
 title: "PM S22"
-hidden: true
 ---
 
 

--- a/markdown/assignments/_index.md
+++ b/markdown/assignments/_index.md
@@ -1,6 +1,7 @@
 ---
 archetype: "chapter"
 title: "Praktikum"
+
 hidden: true
 _build:
   render: always
@@ -8,8 +9,6 @@ _build:
   publishResources: true
 ---
 
-
-# Praktikum
 
 Hier finden Sie die Praktikumsaufgaben. Die Aufgaben sind in zwei Pools sortiert:
 

--- a/markdown/assignments/_index.md
+++ b/markdown/assignments/_index.md
@@ -1,6 +1,7 @@
 ---
 archetype: "chapter"
 title: "Praktikum"
+weight: 0
 
 hidden: true
 _build:

--- a/markdown/assignments/pool_concept/_index.md
+++ b/markdown/assignments/pool_concept/_index.md
@@ -1,6 +1,6 @@
 ---
 archetype: "chapter"
-title: "Pool 'Konzept'"
+title: "Pool Konzept"
 weight: 1
 
 hidden: true

--- a/markdown/assignments/pool_concept/_index.md
+++ b/markdown/assignments/pool_concept/_index.md
@@ -1,12 +1,11 @@
 ---
 archetype: "chapter"
-title: "Pool Konzept"
-hidden: true
+title: "Pool 'Konzept'"
 weight: 1
+
+hidden: true
 ---
 
-
-# Pool "Konzept"
 
 Die Aufgaben aus diesem Pool sind zeitlich an die Vorlesungsthemen geknüpft. Beachten Sie die
 Deadlines für die Abgaben (vgl. `["Fahrplan"]({{< ref "/org/schedule" >}})`{=markdown}).

--- a/markdown/assignments/pool_dungeon/_index.md
+++ b/markdown/assignments/pool_dungeon/_index.md
@@ -1,12 +1,11 @@
 ---
 archetype: "chapter"
-title: "Pool Dungeon"
-hidden: true
+title: "Pool 'Dungeon'"
 weight: 2
+
+hidden: true
 ---
 
-
-# Pool "Dungeon"
 
 Die Aufgaben aus diesem Pool haben keinen direkten zeitlichen Bezug zu den Themen in
 der Vorlesung und können in einer von Ihnen gewählten Reihenfolge bearbeitet werden.

--- a/markdown/assignments/pool_dungeon/_index.md
+++ b/markdown/assignments/pool_dungeon/_index.md
@@ -1,6 +1,6 @@
 ---
 archetype: "chapter"
-title: "Pool 'Dungeon'"
+title: "Pool Dungeon"
 weight: 2
 
 hidden: true

--- a/markdown/assignments/pool_dungeon/group_a/_index.md
+++ b/markdown/assignments/pool_dungeon/group_a/_index.md
@@ -1,12 +1,11 @@
 ---
 archetype: "chapter"
-title: "Gruppe A: Basics"
-hidden: true
+title: "Gruppe A: 'Basics'"
 weight: 1
+
+hidden: true
 ---
 
-
-# Gruppe A "Basics"
 
 Hier finden Sie die Praktikumsaufgaben aus Gruppe A "Basics". Sie benötigen diese Aufgaben, um
 einen rudimentären Dungeon zu erhalten.

--- a/markdown/assignments/pool_dungeon/group_a/_index.md
+++ b/markdown/assignments/pool_dungeon/group_a/_index.md
@@ -1,6 +1,6 @@
 ---
 archetype: "chapter"
-title: "Gruppe A: 'Basics'"
+title: "Gruppe A: Basics"
 weight: 1
 
 hidden: true

--- a/markdown/assignments/pool_dungeon/group_b/_index.md
+++ b/markdown/assignments/pool_dungeon/group_b/_index.md
@@ -1,12 +1,11 @@
 ---
 archetype: "chapter"
-title: "Gruppe B: Monster und Kampf"
-hidden: true
+title: "Gruppe B: 'Monster und Kampf'"
 weight: 2
+
+hidden: true
 ---
 
-
-# Gruppe B "Monster und Kampf"
 
 Hier finden Sie die Praktikumsaufgaben aus Gruppe B "Monster und Kampf". Hier implementieren Sie
 verschiedene Monster und unterschiedliche Kampfsysteme.

--- a/markdown/assignments/pool_dungeon/group_b/_index.md
+++ b/markdown/assignments/pool_dungeon/group_b/_index.md
@@ -1,6 +1,6 @@
 ---
 archetype: "chapter"
-title: "Gruppe B: 'Monster und Kampf'"
+title: "Gruppe B: Monster und Kampf"
 weight: 2
 
 hidden: true

--- a/markdown/assignments/pool_dungeon/group_c/_index.md
+++ b/markdown/assignments/pool_dungeon/group_c/_index.md
@@ -1,12 +1,11 @@
 ---
 archetype: "chapter"
-title: "Gruppe C: Items, Aufbewahrung und Handel"
-hidden: true
+title: "Gruppe C: 'Items, Aufbewahrung und Handel'"
 weight: 3
+
+hidden: true
 ---
 
-
-# Gruppe C "Items, Aufbewahrung und Handel"
 
 Hier finden Sie die Praktikumsaufgaben aus Gruppe C "Items, Aufbewahrung und Handel". In diesen
 Aufgaben implementieren Sie verschiedene Items wie Tränke, Waffen, ... und verschiedene Rucksäcke

--- a/markdown/assignments/pool_dungeon/group_c/_index.md
+++ b/markdown/assignments/pool_dungeon/group_c/_index.md
@@ -1,6 +1,6 @@
 ---
 archetype: "chapter"
-title: "Gruppe C: 'Items, Aufbewahrung und Handel'"
+title: "Gruppe C: Items, Aufbewahrung und Handel"
 weight: 3
 
 hidden: true

--- a/markdown/building/_index.md
+++ b/markdown/building/_index.md
@@ -1,11 +1,9 @@
 ---
 archetype: "chapter"
-title: "Building"
+title: "Bauen von Programmen, Automatisierung, Continuous Integration"
+menuTitle: "Building"
 weight: 4
 ---
-
-
-# Bauen von Programmen, Automatisierung, Continuous Integration
 
 
 `{{< children showhidden="true" >}}`{=markdown}

--- a/markdown/coding/_index.md
+++ b/markdown/coding/_index.md
@@ -1,11 +1,9 @@
 ---
 archetype: "chapter"
-title: "Coding"
+title: "Programmiermethoden und Clean Code"
+menuTitle: "Coding"
 weight: 3
 ---
-
-
-# Programmiermethoden und Clean Code
 
 
 `{{< children showhidden="true" >}}`{=markdown}

--- a/markdown/database/_index.md
+++ b/markdown/database/_index.md
@@ -2,7 +2,7 @@
 archetype: "chapter"
 title: "Zugriffe auf Datenbanken: JDBC"
 menuTitle: "Database"
-weight: 11
+weight: 12
 
 hidden: true
 _build:

--- a/markdown/database/_index.md
+++ b/markdown/database/_index.md
@@ -1,6 +1,7 @@
 ---
 archetype: "chapter"
-title: "Database"
+title: "Zugriffe auf Datenbanken: JDBC"
+menuTitle: "Database"
 weight: 11
 
 hidden: true
@@ -9,9 +10,6 @@ _build:
   list: never
   publishResources: false
 ---
-
-
-# Zugriffe auf Datenbanken: JDBC
 
 
 `{{< children showhidden="true" >}}`{=markdown}

--- a/markdown/frameworks/_index.md
+++ b/markdown/frameworks/_index.md
@@ -2,7 +2,7 @@
 archetype: "chapter"
 title: "Umgang mit Frameworks"
 menuTitle: "Frameworks"
-weight: 12
+weight: 11
 ---
 
 

--- a/markdown/frameworks/_index.md
+++ b/markdown/frameworks/_index.md
@@ -1,11 +1,9 @@
 ---
 archetype: "chapter"
-title: "Frameworks"
+title: "Umgang mit Frameworks"
+menuTitle: "Frameworks"
 weight: 12
 ---
-
-
-# Umgang mit Frameworks
 
 
 `{{< children showhidden="true" >}}`{=markdown}

--- a/markdown/generics/_index.md
+++ b/markdown/generics/_index.md
@@ -1,11 +1,9 @@
 ---
 archetype: "chapter"
-title: "Generics"
+title: "Generics: Umgang mit parametrisierten Typen"
+menuTitle: "Generics"
 weight: 6
 ---
-
-
-# Generics: Umgang mit parametrisierten Typen
 
 
 `{{< children showhidden="true" >}}`{=markdown}

--- a/markdown/git/_index.md
+++ b/markdown/git/_index.md
@@ -1,11 +1,9 @@
 ---
 archetype: "chapter"
-title: "Git"
+title: "Versionierung mit Git"
+menuTitle: "Git"
 weight: 1
 ---
-
-
-# Versionierung mit Git
 
 
 `{{< children showhidden="true" >}}`{=markdown}

--- a/markdown/gui/_index.md
+++ b/markdown/gui/_index.md
@@ -1,11 +1,9 @@
 ---
 archetype: "chapter"
-title: "GUI"
+title: "Graphische Oberflächen mit Swing und Java2D"
+menuTitle: "GUI"
 weight: 10
 ---
-
-
-# Graphische Oberflächen mit Swing und Java2D
 
 
 `{{< children showhidden="true" >}}`{=markdown}

--- a/markdown/java-jvm/_index.md
+++ b/markdown/java-jvm/_index.md
@@ -1,11 +1,9 @@
 ---
 archetype: "chapter"
-title: "Java / JVM"
+title: "Fortgeschrittene Java-Themen und Umgang mit JVM"
+menuTitle: "Java / JVM"
 weight: 7
 ---
-
-
-# Fortgeschrittene Java-Themen und Umgang mit JVM
 
 
 `{{< children showhidden="true" >}}`{=markdown}

--- a/markdown/modern-java/_index.md
+++ b/markdown/modern-java/_index.md
@@ -1,11 +1,9 @@
 ---
 archetype: "chapter"
-title: "Modern Java"
+title: "Modern Java: Funktionaler Stil und Stream-API"
+menuTitle: "Modern Java"
 weight: 8
 ---
-
-
-# Modern Java: Funktionaler Stil und Stream-API
 
 
 `{{< children showhidden="true" >}}`{=markdown}

--- a/markdown/org/_index.md
+++ b/markdown/org/_index.md
@@ -1,15 +1,13 @@
 ---
 archetype: "chapter"
 title: "Organisatorisches"
+
 hidden: true
 _build:
   render: always
   list: never
   publishResources: true
 ---
-
-
-# Organisatorisches
 
 
 `{{< children showhidden="true" >}}`{=markdown}

--- a/markdown/org/_index.md
+++ b/markdown/org/_index.md
@@ -1,6 +1,7 @@
 ---
 archetype: "chapter"
 title: "Organisatorisches"
+weight: 0
 
 hidden: true
 _build:

--- a/markdown/pattern/_index.md
+++ b/markdown/pattern/_index.md
@@ -1,11 +1,9 @@
 ---
 archetype: "chapter"
-title: "Pattern"
+title: "Entwurfsmuster"
+menuTitle: "Pattern"
 weight: 5
 ---
-
-
-# Entwurfsmuster
 
 
 `{{< children showhidden="true" >}}`{=markdown}

--- a/markdown/testing/_index.md
+++ b/markdown/testing/_index.md
@@ -1,11 +1,9 @@
 ---
 archetype: "chapter"
-title: "Testing"
+title: "Testen mit JUnit und Mockito"
+menuTitle: "Testing"
 weight: 2
 ---
-
-
-# Testen mit JUnit und Mockito
 
 
 `{{< children showhidden="true" >}}`{=markdown}

--- a/markdown/threads/_index.md
+++ b/markdown/threads/_index.md
@@ -1,11 +1,9 @@
 ---
 archetype: "chapter"
-title: "Threads"
+title: "Multi-Threading: Parallelisierung von Programmen"
+menuTitle: "Threads"
 weight: 9
 ---
-
-
-# Multi-Threading: Parallelisierung von Programmen
 
 
 `{{< children showhidden="true" >}}`{=markdown}


### PR DESCRIPTION
Im Hugo-Re-Learn-Theme 5.x sind die Chapter so organisiert, dass der Titel als H1-Header genutzt wird. 

- Baue alle `_index.md` so um, dass keine H1-Header mehr existieren
- Nutze bei Bedarf neben `title` auch `menuTitle`
- Ziehe `hidden: true` auf die letzte Zeile (davor eine Leerzeile), um es besser sichtbar zu machen

