### PR TITLE
ILIAS 7.x: Pretty URLs won't work in HTML-Learnmodul anymore

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,9 @@
 #baseURL: "https://pm-dungeon.github.io/PM-Lecture/"
 baseURL: "https://www.fh-bielefeld.de/elearning/data/FH-Bielefeld/lm_data/lm_1359639/"
-canonifyURLs: true
+# https://gohugo.io/content-management/urls/
+canonifyURLs: true   # prepend all relative URLs w/ baseURL
+relativeURLs: false  # do NOT rewrite relative URLs to be relative to current content
+uglyurls: true       # use foo.de/bar.html instead of foo.de/bar/ (our new ILIAS 7.x HTML-Lernmodul won't find landing pages else)
 
 languageCode: "de-DE"
 metaDataFormat: "yaml"

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,4 @@
 baseURL: "https://www.fh-bielefeld.de/elearning/data/FH-Bielefeld/lm_data/lm_1359639/"
-# https://gohugo.io/content-management/urls/
 canonifyURLs: true   # prepend all relative URLs w/ baseURL
 relativeURLs: false  # do NOT rewrite relative URLs to be relative to current content
 uglyurls: true       # use foo.de/bar.html instead of foo.de/bar/ (our new ILIAS 7.x HTML-Lernmodul won't find landing pages else)

--- a/config.yaml
+++ b/config.yaml
@@ -33,17 +33,6 @@ params:
   - "relearn-dark"
   - "green"
 
-outputs:
-  home:
-    - "HTML"
-    - "PRINT"
-  section:
-    - "HTML"
-    - "PRINT"
-  page:
-    - "HTML"
-    - "PRINT"
-
 menu:
   shortcuts:
   - name: "<i class='fas fa-bookmark'></i> Fahrplan"

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,3 @@
-#baseURL: "https://pm-dungeon.github.io/PM-Lecture/"
 baseURL: "https://www.fh-bielefeld.de/elearning/data/FH-Bielefeld/lm_data/lm_1359639/"
 # https://gohugo.io/content-management/urls/
 canonifyURLs: true   # prepend all relative URLs w/ baseURL


### PR DESCRIPTION
Nach dem Upgrade auf ILIAS 7.x werden im HTML-Lernmodul die Landing-Pages nicht mehr gefunden. Statt `foo.de/bar/` muss man nun auf `foo.de/bar.html` zurückfallen (["ugly URLs](https://gohugo.io/content-management/urls/#ugly-urls)).

Leider funktioniert damit dann die neue [Print-Funktionalität](https://mcshelby.github.io/hugo-theme-relearn/basics/configuration/#activate-print-support) im Hugo-Relearn-Theme nicht mehr. 

Ein Issue ist Upstream eröffnet (https://github.com/McShelby/hugo-theme-relearn/issues/322).

Bis dahin ist die Lösung:
1. Ugly-URLs aktivieren (`foo.de/bar/` => `foo.de/bar.html`)
2. Kanonische URLs aktivieren (`foo.de/bar.html` => `<baseURL>/foo.de/bar.html`)
3. Relative URLs deaktivieren (kein Rewriting relativer URLs relativ zum aktuellen Content)
4. [Neue Print-Funktionalität](https://mcshelby.github.io/hugo-theme-relearn/basics/configuration/#activate-print-support) wieder entfernen

Fixes #596 
