### PR TITLE
[VL] Use 'href' key/value pair in 'bsp' span

### DIFF
--- a/markdown/building/ant.md
+++ b/markdown/building/ant.md
@@ -184,7 +184,7 @@ Works on my machine ...
 *   `<copy file="myfile.txt" tofile="../bak/mycopy.txt" />`
 *   `<move file="src/file.orig" tofile="bak/file.moved" />`
 
-[Beispiel build.xml, `init` und `clean`]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/building/src/ant/build.xml"}
+[Beispiel build.xml, init und clean]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/building/src/ant/build.xml"}
 :::
 
 

--- a/markdown/building/ant.md
+++ b/markdown/building/ant.md
@@ -128,7 +128,7 @@ Works on my machine ...
 
 => Überblick: [ant.apache.org/manual/tasksoverview.html](https://ant.apache.org/manual/tasksoverview.html)
 
-[Konsole/IDE: ant -f [hello.xml](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/building/src/ant/hello.xml)]{.bsp}
+[Konsole/IDE: ant -f hello.xml]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/building/src/ant/hello.xml"}
 
 
 ## Properties: Name-Wert-Paare
@@ -157,7 +157,7 @@ Works on my machine ...
     `ant -Dwuppie=fluppie`
 
 ::: notes
-[Beispiel [build.xml](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/building/src/ant/build.xml), Properties]{.bsp}
+[Beispiel build.xml, Properties]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/building/src/ant/build.xml"}
 :::
 
 
@@ -184,7 +184,7 @@ Works on my machine ...
 *   `<copy file="myfile.txt" tofile="../bak/mycopy.txt" />`
 *   `<move file="src/file.orig" tofile="bak/file.moved" />`
 
-[Beispiel [build.xml](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/building/src/ant/build.xml), `init` und `clean`]{.bsp}
+[Beispiel build.xml, `init` und `clean`]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/building/src/ant/build.xml"}
 :::
 
 
@@ -469,7 +469,7 @@ ivy-2.5.0.jar von /usr/share/java/ivy.jar nach ~/.ant/lib/ kopieren
 Ivy-Cache unter ~/.ivy2/cache/
 -->
 
-[Demo: [ivydemo.xml](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/building/src/ant/ivydemo.xml)]{.bsp}
+[Demo: ivydemo.xml]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/building/src/ant/ivydemo.xml"}
 
 
 ## Ausblick: Weitere Build-Systeme

--- a/markdown/building/docker.md
+++ b/markdown/building/docker.md
@@ -294,7 +294,7 @@ auch die selben Versionsstände haben. In der Praxis löscht man deshalb das alt
 und erstellt ein neues, welches dann die aktualisierte Software enthält.
 :::
 
-[Beispiel: [debian-latex.df](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/building/src/docker/debian-latex.df)]{.bsp}
+[Beispiel: debian-latex.df]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/building/src/docker/debian-latex.df"}
 
 
 ## CI-Pipeline (GitLab)

--- a/markdown/building/maven.md
+++ b/markdown/building/maven.md
@@ -142,7 +142,7 @@ Jar-File im Maven-Repository zu finden sein (sofern es denn veröffentlicht wird
 für die Dependencies findet man ebenfalls auf [MavenCentral](https://mvnrepository.com/repos/central).
 :::
 
-[Demo für [MavenCentral](https://mvnrepository.com/repos/central) (Suche, Einträge)]{.bsp}
+[Demo für MavenCentral (Suche, Einträge)]{.bsp}
 
 
 ## Project Object Model: Plugins
@@ -208,7 +208,7 @@ ein erster Einstieg ist die [Plugin-API](https://maven.apache.org/ref/3.8.1/mave
     führt die Klasse `de.fhb.pm.Main` aus.
 :::
 
-[Demo: [pom.xml](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/building/src/maven/pom.xml)]{.bsp}
+[Demo: pom.xml]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/building/src/maven/pom.xml"}
 
 
 ## Wrap-Up

--- a/markdown/coding/codingrules.md
+++ b/markdown/coding/codingrules.md
@@ -241,7 +241,7 @@ docker pull gradle
 docker run --rm -it  -v "$PWD":/data -w /data  --entrypoint "bash"  gradle
 -->
 
-[Demo: Konfiguration Formatter (IDE), [Spotless/Gradle](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/coding/src/formatter/)]{.bsp}
+[Demo: Konfiguration Formatter (IDE), Spotless/Gradle]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/coding/src/formatter/"}
 
 
 ## Metriken: Kennzahlen für verschiedene Aspekte zum Code
@@ -359,7 +359,7 @@ docker pull gradle
 docker run --rm -it  -v "$PWD":/data -w /data  --entrypoint "bash"  gradle
 -->
 
-[Demo: IntelliJ, [Checkstyle/Gradle](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/coding/src/checkstyle/)]{.bsp}
+[Demo: IntelliJ, Checkstyle/Gradle]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/coding/src/checkstyle/"}
 
 
 ## Checkstyle: Konfiguration
@@ -448,7 +448,7 @@ docker pull gradle
 docker run --rm -it  -v "$PWD":/data -w /data  --entrypoint "bash"  gradle
 -->
 
-[Demo: [SpotBugs/Gradle](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/coding/src/spotbugs/)]{.bsp}
+[Demo: SpotBugs/Gradle]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/coding/src/spotbugs/"}
 
 
 ## Konfiguration für das PM-Praktikum (Format, Metriken, Checkstyle, SpotBugs)

--- a/markdown/coding/logging.md
+++ b/markdown/coding/logging.md
@@ -100,7 +100,7 @@ Zusätzlich gibt es noch Filter, mit denen man Nachrichten (zusätzlich zum
 Log-Level) nach weiteren Kriterien filtern kann.
 :::
 
-[Konsole: [logging.LoggingDemo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/coding/src/logging/LoggingDemo.java)]{.bsp}
+[Konsole: logging.LoggingDemo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/coding/src/logging/LoggingDemo.java"}
 
 
 ## Erzeugen neuer Logger
@@ -170,7 +170,7 @@ public void log(Level level, String msg);
     *   Prüfung mit `public boolean isLoggable(Level)`
     *   Setzen mit `public void setLevel(Level)`
 
-[Konsole: [logging.LoggingLevel](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/coding/src/logging/LoggingLevel.java)]{.bsp}
+[Konsole: logging.LoggingLevel]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/coding/src/logging/LoggingLevel.java"}
 
 ::: notes
 => Warum wird im Beispiel nach `log.setLevel(Level.ALL);` trotzdem nur
@@ -202,7 +202,7 @@ ab `INFO` geloggt? Wer erzeugt eigentlich die Ausgaben?!
 *   Handler nutzen zur Formatierung der Ausgabe einen `Formatter`
 *   Standard-Formatter: `SimpleFormatter` und `XMLFormatter`
 
-[Konsole: [logging.LoggingHandler](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/coding/src/logging/LoggingHandler.java)]{.bsp}
+[Konsole: logging.LoggingHandler]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/coding/src/logging/LoggingHandler.java"}
 
 ::: notes
 => Warum wird im Beispiel nach dem Auskommentieren von
@@ -226,7 +226,7 @@ angezeigt (ab `INFO` aufwärts)?!
         *   Abschalten mit `Logger#setUseParentHandlers(false);`
     *   Diese leiten  [an ihre Handler sowie]{.notes}  an ihren Eltern-Logger weiter (unabhängig von Log-Level!)
 
-[Konsole: [logging.LoggingParent](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/coding/src/logging/LoggingParent.java); Tafel: Skizze Logger-Baum]{.bsp}
+[Konsole: logging.LoggingParent; Tafel: Skizze Logger-Baum]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/coding/src/logging/LoggingParent.java"}
 
 
 ## Wrap-Up

--- a/markdown/coding/smells.md
+++ b/markdown/coding/smells.md
@@ -173,7 +173,7 @@ hat, Zeit in ordentliche Arbeit zu investieren, weil der Code ja eh schon
 schlecht ist ... Das wird mit der Zeit nicht besser ...
 :::::::::
 
-[["Broken Windows" Phänomen](https://en.wikipedia.org/wiki/Broken_windows_theory)]{.bsp}
+["Broken Windows" Phänomen]{.bsp href="https://en.wikipedia.org/wiki/Broken_windows_theory"}
 
 ::::::::: notes
 ### Maßeinheit für Code-Qualität ;-)

--- a/markdown/frameworks/intro.md
+++ b/markdown/frameworks/intro.md
@@ -161,7 +161,7 @@ ist ein einfaches und schlankes Framework zu bevorzugen.
 
 **Frameworks müssen ge-/erlernt werden.**
 
-[Demo: [Web-Anwendung für Zufallszahlen](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/frameworks/src/javalin/)]{.bsp}
+[Demo: Web-Anwendung für Zufallszahlen]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/frameworks/src/javalin/"}
 
 
 ## Wrap-Up

--- a/markdown/generics/bounds-wildcards.md
+++ b/markdown/generics/bounds-wildcards.md
@@ -69,7 +69,7 @@ Cps<String> c;  // Fehler!!!
 ::: notes
 _Anmerkung_: Der Typ-Parameter ist analog auch mit `super` (nach unten) einschränkbar
 
-[Beispiel [bounds.Cps](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/generics/src/bounds/Cps.java)]{.bsp}
+[Beispiel bounds.Cps]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/generics/src/bounds/Cps.java"}
 :::
 
 
@@ -152,7 +152,7 @@ public class X {
 (auch wenn ein `B` ein `A` ist, vgl. spätere Sitzung zu Generics und
 Vererbung ...)!
 
-[Beispiel [wildcards.v1.X](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/generics/src/wildcards/v1/X.java)]{.bsp}
+[Beispiel wildcards.v1.X]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/generics/src/wildcards/v1/X.java"}
 
 ### Zweiter Versuch mit Wildcards (_A_ und _B_ und _main()_ wie oben)
 
@@ -172,7 +172,7 @@ Laufvariablen in der `for`-Schleife dann `Object` nehmen. Aber
 Methode `X#printInfo` dank des Wildcards auch mit allen anderen
 Typen aufrufen ...
 
-[Beispiel [wildcards.v2.X](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/generics/src/wildcards/v2/X.java)]{.bsp}
+[Beispiel wildcards.v2.X]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/generics/src/wildcards/v2/X.java"}
 
 ### Dritter Versuch (Lösung) mit Wildcards und Bounds (_A_ und _B_ und _main()_ wie oben)
 
@@ -190,7 +190,7 @@ in der Schleife kann man sich auf den gemeinsamen Obertyp `A` abstützen
 und hat dann auch wieder die `printInfo`-Methode zur Verfügung ...
 :::::::::
 
-[Konsole [wildcards.v3.X](https://github.com/Programmiermethoden/PM-Lecture/tree/master/markdown/generics/src/wildcards/v3)]{.bsp}
+[Konsole wildcards.v3.X]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/tree/master/markdown/generics/src/wildcards/v3"}
 
 
 ## Wrap-Up

--- a/markdown/generics/classes-methods.md
+++ b/markdown/generics/classes-methods.md
@@ -155,7 +155,7 @@ b.foo("huhu");  // Fehlermeldung vom Compiler
 ```
 
 ::::::::: notes
-[Beispiel: [classes.GenericClasses](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/generics/src/classes/GenericClasses.java)]{.bsp}
+[Beispiel: classes.GenericClasses]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/generics/src/classes/GenericClasses.java"}
 
 ### Typ-Inferenz
 
@@ -289,7 +289,7 @@ m.myst("Essen", "lecker");   // String, String  => T: String
 m.myst(1.0, 1);              // Double, Integer => T: Number
 ```
 
-[Beispiel [methods.GenericMethods](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/generics/src/methods/GenericMethods.java)]{.bsp}
+[Beispiel methods.GenericMethods]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/generics/src/methods/GenericMethods.java"}
 
 ::::::::: notes
 Reihenfolge der Suche nach passender Methode gilt auch für nicht-generisch überladene Methoden

--- a/markdown/generics/generics-polymorphism.md
+++ b/markdown/generics/generics-polymorphism.md
@@ -139,7 +139,7 @@ Compiler-Prüfung. Da würde das von Arrays bekannte Verhalten Probleme machen .
 **Kovarianz**: Arrays sind _kovariant_, d.h. ein Array vom Typ `String[]` ist wegen
 `String extends Object` ein Untertyp von `Object[]`.
 
-[Beispiel [arrays.X](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/generics/src/arrays/X.java)]{.bsp}
+[Beispiel arrays.X]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/generics/src/arrays/X.java"}
 :::
 
 

--- a/markdown/git/remotes.md
+++ b/markdown/git/remotes.md
@@ -245,7 +245,7 @@ Zwischenzeit weiter geschoben - dann muss die Aktualisierung erneut durchgeführ
 werden).
 :::::::::
 
-[Beispiel für Zusammenführen (merge und push), Anmerkung zu _fast forward merge_]{.bsp}
+[Beispiel für Zusammenführen (merge und push), Anmerkung zu fast forward merge]{.bsp}
 
 
 ## Branches und Remotes

--- a/markdown/gui/basics.md
+++ b/markdown/gui/basics.md
@@ -161,10 +161,10 @@ genauer ansehen.
 
 Siehe auch ["Concurrency in Swing"](https://docs.oracle.com/javase/tutorial/uiswing/concurrency/index.html).
 
-[Beispiel: [basics.FirstWindow](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/basics/FirstWindow.java)]{.bsp}
+[Beispiel: basics.FirstWindow]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/basics/FirstWindow.java"}
 :::
 
-[Demo: [basics.SecondWindow](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/basics/SecondWindow.java)]{.bsp}
+[Demo: basics.SecondWindow]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/basics/SecondWindow.java"}
 
 
 ## Wrap-Up

--- a/markdown/gui/events.md
+++ b/markdown/gui/events.md
@@ -100,7 +100,7 @@ bekommt und viele weitere.
 
 *   Sequentielles Abarbeiten der Events bzw. Benachrichtigung der Observer
 
-[Demo: [events.ListenerDemo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/events/ListenerDemo.java)]{.bsp}
+[Demo: events.ListenerDemo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/events/ListenerDemo.java"}
 
 
 ## Wie komme ich an die Daten eines Events?
@@ -109,7 +109,7 @@ bekommt und viele weitere.
 
 **Event-Objekte**: Quelle des Events plus aufgetretene Daten
 
-[Demo: [events.MouseListenerDemo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/events/MouseListenerDemo.java)]{.bsp}
+[Demo: events.MouseListenerDemo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/events/MouseListenerDemo.java"}
 
 
 ## Listener vs. Adapter
@@ -135,7 +135,7 @@ Abhilfe: **Adapter**-Klassen:
 
 => Nur benötigte Listener-Methoden überschreiben.
 
-[Demo: [events.MouseAdapterDemo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/events/MouseAdapterDemo.java)]{.bsp}
+[Demo: events.MouseAdapterDemo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/events/MouseAdapterDemo.java"}
 
 
 ## Wrap-Up

--- a/markdown/gui/java2d.md
+++ b/markdown/gui/java2d.md
@@ -61,7 +61,7 @@ fhmedia:
 
 ![](images/java2d.png){width="40%"}
 
-[Demo: [java2d.simplegame.J2DTeaser](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/java2d/simplegame/J2DTeaser.java)]{.bsp}
+[Demo: java2d.simplegame.J2DTeaser]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/java2d/simplegame/J2DTeaser.java"}
 
 
 ## Einführung in die Java 2D API
@@ -144,7 +144,7 @@ Vorher Strichfarbe setzen: `Graphics.setColor(Color color)`:
     public Color(int r, int g, int b)  // Rot/Grün/Blau, Werte zw. 0 und 255
     ```
 
-[Demo: [java2d.SimpleDrawings](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/java2d/SimpleDrawings.java)]{.bsp}
+[Demo: java2d.SimpleDrawings]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/java2d/SimpleDrawings.java"}
 
 
 ## Fonts und Strings
@@ -165,7 +165,7 @@ public void drawString(String str, int x, int y);
 
 Vorher Font und Farbe setzen!
 
-[Demo: [java2d.SimpleFonts](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/java2d/SimpleFonts.java)]{.bsp}
+[Demo: java2d.SimpleFonts]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/java2d/SimpleFonts.java"}
 
 
 ## Einfache Polygone definieren
@@ -204,7 +204,7 @@ Statt `drawPolygon()` ....
 
 Vorher Farbe setzen!
 
-[Demo: [java2d.SimplePoly](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/java2d/SimplePoly.java)]{.bsp}
+[Demo: java2d.SimplePoly]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/java2d/SimplePoly.java"}
 
 
 ## Ausblick I: Umgang mit Bildern
@@ -365,7 +365,7 @@ Weitere evtl. nützliche Methoden:
     und damit ein Neuzeichnen aller  Objekte ausgelöst
 :::
 
-[Demo: [java2d.simplegame.J2DTeaser](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/java2d/simplegame/J2DTeaser.java)]{.bsp}
+[Demo: java2d.simplegame.J2DTeaser]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/java2d/simplegame/J2DTeaser.java"}
 
 
 ## Wrap-Up

--- a/markdown/gui/layouts.md
+++ b/markdown/gui/layouts.md
@@ -90,7 +90,7 @@ Mit den Methoden `setHgap()` und `setVgap()` kann der Abstand zwischen den Kompo
 werden (horizontal und vertikal, Abstände in Pixel).
 :::
 
-[Demo: [layout.Border](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/layout/Border.java)]{.bsp}
+[Demo: layout.Border]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/layout/Border.java"}
 
 
 ## _FlowLayout_
@@ -118,7 +118,7 @@ Per Default werden die Komponenten zentriert angeordnet. Über den Konstruktor o
 werden, ebenso wie ein vertikales und horizontales Padding zwischen den Komponenten.
 :::
 
-[Demo: [layout.Flow](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/layout/Flow.java)]{.bsp}
+[Demo: layout.Flow]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/layout/Flow.java"}
 
 
 ## _GridLayout_
@@ -148,7 +148,7 @@ Auch in diesem Layout kann das Padding über die Methoden `setHgap()` bzw. `setV
 werden.
 :::
 
-[Demo: [layout.Grid](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/layout/Grid.java)]{.bsp}
+[Demo: layout.Grid]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/layout/Grid.java"}
 
 
 ## Komplexer Layout-Manager: _GridBagLayout_
@@ -200,7 +200,7 @@ des Containers in der jeweiligen Richtung wird der neue Platz unter den Slots ge
 aufgeteilt.
 :::
 
-[Demo: [layout.GridBag](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/layout/GridBag.java)]{.bsp}
+[Demo: layout.GridBag]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/layout/GridBag.java"}
 
 
 ## Wrap-Up

--- a/markdown/gui/tables.md
+++ b/markdown/gui/tables.md
@@ -73,7 +73,7 @@ contentPane.add(table, BorderLayout.CENTER);
 ```
 :::
 
-[Demo: [tables.SimpleTable](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/tables/SimpleTable.java)]{.bsp}
+[Demo: tables.SimpleTable]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/tables/SimpleTable.java"}
 
 
 ## Selektierbare und sortierbare Tabelle
@@ -106,7 +106,7 @@ contentPane.add(table, BorderLayout.CENTER);
     }});
     ```
 
-[Demo: [tables.SelectTable](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/tables/SelectTable.java)]{.bsp}
+[Demo: tables.SelectTable]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/tables/SelectTable.java"}
 
 
 ## Einschub: MVC-Pattern
@@ -201,7 +201,7 @@ Zusätzlich kann man beim Modell eigene Listener registrieren, die auf Events du
 Änderungen der Tabelle reagieren können.
 :::
 
-[Demo: [tables.ModelTable](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/tables/ModelTable.java)]{.bsp}
+[Demo: tables.ModelTable]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/tables/ModelTable.java"}
 
 
 ## Wrap-Up

--- a/markdown/gui/widgets.md
+++ b/markdown/gui/widgets.md
@@ -83,7 +83,7 @@ fhmedia:
     radioGroup.add(b1);    radioGroup.add(b2);
     ```
 
-[Demo: [widgets.RadioButtonDemo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/widgets/RadioButtonDemo.java)]{.bsp}
+[Demo: widgets.RadioButtonDemo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/widgets/RadioButtonDemo.java"}
 
 
 ## Dateien oder Verzeichnisse auswählen: _JFileChooser_
@@ -114,7 +114,7 @@ if (fc.showOpenDialog() == JFileChooser.APPROVE_OPTION)
     *   `String getDescription()`
 :::
 
-[Demo: [widgets.FileChooserDemo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/widgets/FileChooserDemo.java)]{.bsp}
+[Demo: widgets.FileChooserDemo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/widgets/FileChooserDemo.java"}
 
 
 ## TabbedPane und Scroll-Bars
@@ -154,7 +154,7 @@ if (fc.showOpenDialog() == JFileChooser.APPROVE_OPTION)
 *   Wirkung der Scrollpane zeigen (letzter Tab)
 -->
 
-[Demo: [widgets.TabbedPaneDemo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/widgets/TabbedPaneDemo.java)]{.bsp}
+[Demo: widgets.TabbedPaneDemo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/widgets/TabbedPaneDemo.java"}
 
 
 ## Dialoge mit _JOptionPane_
@@ -182,7 +182,7 @@ der Elternkomponente. Diese wird als Referenz übergeben und bekommt erst wieder
 Fokus, wenn der Dialog geschlossen wurde.
 :::
 
-[Demo: [widgets.DialogDemo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/widgets/DialogDemo.java)]{.bsp}
+[Demo: widgets.DialogDemo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/widgets/DialogDemo.java"}
 
 
 ## Menüs mit _JMenuBar_, _JMenu_ und _JMenuItem_
@@ -212,7 +212,7 @@ Wenn man mit der Maus ein Menü ausklappt, wird eine Liste der Menüeinträge an
 sind vom Typ `JMenuItem` und verhalten sich wie Buttons.
 :::
 
-[Demo: [widgets.MenuDemo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/widgets/MenuDemo.java)]{.bsp}
+[Demo: widgets.MenuDemo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/widgets/MenuDemo.java"}
 
 
 ## Kontextmenü mit _JPopupMenu_
@@ -260,7 +260,7 @@ myFrame.addMouseListener(new MouseAdapter() {
 ```
 :::
 
-[Demo: [widgets.PopupDemo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/widgets/PopupDemo.java)]{.bsp}
+[Demo: widgets.PopupDemo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/gui/src/widgets/PopupDemo.java"}
 
 
 ## Wrap-Up

--- a/markdown/java-jvm/annotations.md
+++ b/markdown/java-jvm/annotations.md
@@ -69,7 +69,7 @@ public class B extends A {
 }
 ```
 
-[[Beispiel: [annotations.B](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/annotations/B.java)]{.bsp}]{.notes}
+[[Beispiel: annotations.B]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/annotations/B.java"}]{.notes}
 
 \pause
 \bigskip
@@ -108,7 +108,7 @@ generieren: `Preferences > Java > Code Style > Add @Override annotation ...`.
     *   Webservices: `@WebService`, `@WebMethod`
     *   ...
 
-[Demo: [annotations.B](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/annotations/B.java): \@Override, \@Deprecated]{.bsp}
+[Demo: annotations.B: \@Override, \@Deprecated]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/annotations/B.java"}
 
 ::::::::: notes
 Jetzt schauen wir uns erst einmal die Auswirkungen von `@Override` und `@Deprecated`
@@ -169,7 +169,7 @@ Hier noch einmal exemplarisch die wichtigsten Elemente, die an
 "`public`" sichtbaren Methoden verwendet werden.
 :::
 
-[[Beispiel: [annotations.B](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/annotations/B.java) (Javadoc)]{.bsp}]{.notes}
+[[Beispiel: annotations.B (Javadoc)]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/annotations/B.java"}]{.notes}
 
 
 ## \@NotNull mit IntelliJ
@@ -215,7 +215,7 @@ public void foo(@NotNull Object o) {
 }
 ```
 
-[Demo: [annotations.WuppieAnnotation](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/annotations/WuppieAnnotation.java): \@NotNull]{.bsp}
+[Demo: annotations.WuppieAnnotation: \@NotNull]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/annotations/WuppieAnnotation.java"}
 
 ::: notes
 ### IntelliJ inferiert mit \@NotNull mögliche _null_-Werte
@@ -244,7 +244,7 @@ public @interface MyThirdAnnotation {
 public class C {}
 ```
 
-[Demo: [annotations.C](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/annotations/C.java)]{.bsp}
+[Demo: annotations.C]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/annotations/C.java"}
 
 ::::::::: notes
 ### Definition einer Annotation
@@ -403,7 +403,7 @@ public class Foo extends AbstractProcessor {
 }
 ```
 
-[Demo: [annotations.C](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/annotations/C.java) und [annotations.Foo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/annotations/Foo.java), [META-INF](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/META-INF/)]{.bsp}
+[Demo: annotations.C und annotations.Foo, META-INF]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/META-INF/"}
 
 ::::::::: notes
 1.  Der Annotation-Processor sollte von `AbstractProcessor` ableiten

--- a/markdown/java-jvm/collections.md
+++ b/markdown/java-jvm/collections.md
@@ -233,7 +233,7 @@ der Elemente der eigenen Klasse genutzt werden kann. Damit die eigene Klasse auc
 genutzt werden kann, muss sie aber auch noch `Iterable<T>` implementieren.
 
 
-[Beispiel: [iterator_example.*](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/collections/iterator_example/)]{.bsp}
+[Beispiel: iterator_example.*]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/collections/iterator_example/"}
 :::
 
 
@@ -319,7 +319,7 @@ Die Unterklasse `LinkedHashMap<K,V>` kann Ordnung zwischen den Elementen halten.
 eine doppelt verkettete Liste verwendet.
 
 
-[Beispiel: [hash_example.HashCodeExample](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/collections/hash_example/HashCodeExample.java)]{.bsp}
+[Beispiel: hash_example.HashCodeExample]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/collections/hash_example/HashCodeExample.java"}
 :::
 
 
@@ -399,7 +399,7 @@ Spielregeln:
 
 
 ::: notes
-[Beispiel: [hash_example.HashCodeExample](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/collections/hash_example/HashCodeExample.java)]{.bsp}
+[Beispiel: hash_example.HashCodeExample]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/collections/hash_example/HashCodeExample.java"}
 :::
 
 

--- a/markdown/java-jvm/configuration.md
+++ b/markdown/java-jvm/configuration.md
@@ -244,7 +244,7 @@ Die Funktionsweise der einzelnen Klassen wird in der Demo kurz angerissen. Schau
 zusätzlich in die Dokumentation.
 :::
 
-[Demo: Einbinden von Libs, [cli.Args](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/cli/Args.java)]{.bsp}
+[Demo: Einbinden von Libs, cli.Args]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/cli/Args.java"}
 
 
 ## Laden und Speichern von Konfigurationsdaten
@@ -306,7 +306,7 @@ gewicht=12
     ```
     :::
 
-[Demo: [cli.Props](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/cli/Props.java), Hinweis auf "Apache Commons Configuration"]{.bsp}
+[Demo: cli.Props, Hinweis auf "Apache Commons Configuration"]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/cli/Props.java"}
 
 ::: notes
 `java.util.Properties` sind eine einfache und im JDK bereits eingebaute Möglichkeit,

--- a/markdown/java-jvm/enums.md
+++ b/markdown/java-jvm/enums.md
@@ -68,7 +68,7 @@ public class Studi {
 :::
 
 [[Probleme: Typsicherheit, Kontext]{.bsp}]{.slides}
-[[Beispiel [enums.v1.Studi](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/enums/v1/Studi.java)]{.bsp}]{.notes}
+[[Beispiel enums.v1.Studi]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/enums/v1/Studi.java"}]{.notes}
 
 
 ## Verbesserung: Einfache Aufzählung
@@ -107,7 +107,7 @@ public enum Fach {
 3.  Enumerations stellen einen neuen Typ dar: hier der Typ `Fach`
 4.  Methoden: `name()`, `ordinal()`, `values()`, `toString()`
 
-[Erinnerung: Bedeutung von *static* und *final*]{.bsp}
+[Erinnerung: Bedeutung von static und final]{.bsp}
 
 
 ::::::::: notes
@@ -146,7 +146,7 @@ public enum Fach {
     }
     ```
 
-    [Beispiel [enums.FinalDemo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/enums/FinalDemo.java)]{.bsp}
+    [Beispiel enums.FinalDemo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/enums/FinalDemo.java"}
 
 *   Methoden: `final` deklarierte Methoden können bei Vererbung nicht überschrieben werden
 *   Klassen: von `final` deklarierten Klassen können keine Unterklassen gebildet werden
@@ -183,7 +183,7 @@ Außerdem können wir folgende Eigenschaften nutzen (u.a., s.u.):
 *   Enumerations haben Methode `final T[] values()` für die Iteration über die Konstanten
 :::
 
-[Demo: [enums.v2.Studi](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/enums/v2/Studi.java)]{.bsp}
+[Demo: enums.v2.Studi]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/enums/v2/Studi.java"}
 
 
 ## Enum: Genauer betrachtet
@@ -255,7 +255,7 @@ public enum Fach {
 **Hinweis**: Diese Methoden gibt es auch bei den "einfachen" Enumerationen (s.o.).
 :::
 
-[Demo: [enums.v3](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/enums/v3/)]{.bsp}
+[Demo: enums.v3]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/enums/v3/"}
 
 
 ## Wrap-Up

--- a/markdown/java-jvm/exceptions.md
+++ b/markdown/java-jvm/exceptions.md
@@ -362,7 +362,7 @@ int getFirstLineAsInt(String pathToFile) {
 }
 ```
 
-[Zeigen: [exceptions.HowMuchTry](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/exceptions/HowMuchTry.java)]{.bsp}
+[Zeigen: exceptions.HowMuchTry]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/exceptions/HowMuchTry.java"}
 
 
 ::: notes

--- a/markdown/java-jvm/reflection.md
+++ b/markdown/java-jvm/reflection.md
@@ -289,7 +289,7 @@ der Parameter und deren Typ und Annotationen fragen etc. ... Schauen Sie am best
 einmal selbst in die API hinein.
 :::
 
-[Demo: [reflection.ReflectionDemo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/reflection/ReflectionDemo.java)]{.bsp}
+[Demo: reflection.ReflectionDemo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/reflection/ReflectionDemo.java"}
 
 
 ## Hinweis: Klassen außerhalb des Classpath laden
@@ -303,7 +303,7 @@ Class<?> c1 = Class.forName("org.wuppie.Fluppie", true, ucl);
 Class<?> c2 = ucl.loadClass("org.wuppie.Fluppie");
 ```
 
-[Bemerkung zu Ordnerstruktur und Classpath; Demo: [reflection.ClassLoaderDemo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/reflection/ClassLoaderDemo.java)]{.bsp}
+[Bemerkung zu Ordnerstruktur und Classpath; Demo: reflection.ClassLoaderDemo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/reflection/ClassLoaderDemo.java"}
 
 ::: notes
 Mit `Class.forName("reflection.Studi")` können Sie die Klasse `Studi` im

--- a/markdown/java-jvm/regexp.md
+++ b/markdown/java-jvm/regexp.md
@@ -197,7 +197,7 @@ Deshalb muss der Backslash i.d.R. geschützt ("escaped") werden.
     public boolean matches(String regex)
     ```
 
-[Demo: [regexp.StringSplit](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/regexp/StringSplit.java)]{.bsp}
+[Demo: regexp.StringSplit]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/regexp/StringSplit.java"}
 
 \pause
 
@@ -250,7 +250,7 @@ Deshalb muss der Backslash i.d.R. extra geschützt ("escaped") werden.
 Sie im Java-String "`a\\\\\\\\bc`" schreiben!
 :::
 
-[Demo: [regexp.MatchFind](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/regexp/MatchFind.java)]{.bsp}
+[Demo: regexp.MatchFind]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/regexp/MatchFind.java"}
 
 
 ## Unterschied zw. Finden und Matchen
@@ -305,7 +305,7 @@ Matcher m = p.matcher("A 12 A 45 A");
 String result = m.group(); // ???
 ```
 
-[Demo: [regexp.Quantifier](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/regexp/Quantifier.java)]{.bsp}
+[Demo: regexp.Quantifier]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/regexp/Quantifier.java"}
 
 ::: notes
 `Matcher#group` liefert die Inputsequenz, auf die der Matcher angesprochen hat.
@@ -409,7 +409,7 @@ zuzugreifen:
 
 `(Studi){2}` => "StudiStudi"
 
-[Demo: [regexp.Groups](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/regexp/Groups.java)]{.bsp}
+[Demo: regexp.Groups]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/regexp/Groups.java"}
 
 
 ## Gruppen und Backreferences
@@ -443,7 +443,7 @@ Matche zwei Ziffern, gefolgt von den selben zwei Ziffern
 
     => Backreference: `\k<name>`
 
-[Demo: [regexp.Backref](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/regexp/Backref.java)]{.bsp}
+[Demo: regexp.Backref]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/regexp/Backref.java"}
 
 
 ## Beispiel Gruppen und Backreferences

--- a/markdown/java-jvm/serialisation.md
+++ b/markdown/java-jvm/serialisation.md
@@ -216,7 +216,7 @@ Weitere Links:
     *   https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/io/Serializable.html
 :::
 
-[Demo: [serial.SerializableStudi](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/serial/SerializableStudi.java)]{.bsp}
+[Demo: serial.SerializableStudi]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/java-jvm/src/serial/SerializableStudi.java"}
 
 
 ## Wrap-Up

--- a/markdown/modern-java/defaultmethods.md
+++ b/markdown/modern-java/defaultmethods.md
@@ -151,7 +151,7 @@ public class DefaultTest1 {
 }
 ```
 
-[Demo: [defaultmethods.rule1.DefaultTest1](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/defaultmethods/rule1/DefaultTest1.java)]{.bsp}
+[Demo: defaultmethods.rule1.DefaultTest1]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/defaultmethods/rule1/DefaultTest1.java"}
 
 ::: notes
 Die Klasse `E` erbt sowohl von Klasse `C` als auch vom Interface `A` die Methode `hello()`
@@ -182,7 +182,7 @@ public class DefaultTest2 {
 }
 ```
 
-[Demo: [defaultmethods.rule2.DefaultTest2](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/defaultmethods/rule2/DefaultTest2.java)]{.bsp}
+[Demo: defaultmethods.rule2.DefaultTest2]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/defaultmethods/rule2/DefaultTest2.java"}
 
 ::: notes
 Die Klasse `D` erbt sowohl vom Interface `A` als auch vom Interface `B` die Methode `hello()`
@@ -216,7 +216,7 @@ public class DefaultTest3 {
 }
 ```
 
-[Demo: [defaultmethods.rule3.DefaultTest3](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/defaultmethods/rule3/DefaultTest3.java)]{.bsp}
+[Demo: defaultmethods.rule3.DefaultTest3]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/defaultmethods/rule3/DefaultTest3.java"}
 
 ::: notes
 Die Klasse `D` erbt sowohl vom Interface `A` als auch vom Interface `B` die Methode `hello()`
@@ -260,7 +260,7 @@ Die Klasse `D` erbt sowohl von Klasse `C` als auch von den Interfaces `A` und `B
 `hello()` (Mehrfachvererbung). In diesem Fall "gewinnt" die Implementierung aus Klasse `C`: Klassen
 gewinnen immer (Regel 1).
 
-[Beispiel: [defaultmethods.quiz.DefaultTest](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/defaultmethods/quiz/DefaultTest.java)]{.bsp}
+[Beispiel: defaultmethods.quiz.DefaultTest]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/defaultmethods/quiz/DefaultTest.java"}
 :::
 
 

--- a/markdown/modern-java/lambdas.md
+++ b/markdown/modern-java/lambdas.md
@@ -143,7 +143,7 @@ public class Outer {
 }
 ```
 
-[Beispiel mit Iterator als innere Klasse: [nested.StudiListNested](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/nested/StudiListNested.java)]{.bsp}
+[Beispiel mit Iterator als innere Klasse: nested.StudiListNested]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/nested/StudiListNested.java"}
 
 ### Statische innere Klassen ("_Static Nested Classes_")
 
@@ -193,7 +193,7 @@ sl.sort(
 *   Nutzung typischerweise bei GUIs: Event-Handler etc.
 :::
 
-[Demo: [nested.DemoAnonymousInnerClass](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/nested/DemoAnonymousInnerClass.java)]{.bsp}
+[Demo: nested.DemoAnonymousInnerClass]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/nested/DemoAnonymousInnerClass.java"}
 
 
 ## Vereinfachung mit Lambda-Ausdruck
@@ -215,7 +215,7 @@ sl.sort(
 sl.sort( (Studi o1, Studi o2) -> o1.getCredits() - o2.getCredits() );
 ```
 
-[[Hinweis auf **funktionales Interface**]{.bsp}]{.slides}
+[[Hinweis auf funktionales Interface]{.bsp}]{.slides}
 
 ::: notes
 **Anmerkung**: Damit für den Parameter alternativ auch ein Lambda-Ausdruck verwendet
@@ -223,7 +223,7 @@ werden kann, muss der erwartete Parameter vom Typ her ein "**funktionales Interf
 (s.u.) sein!
 :::
 
-[Demo: [nested.DemoLambda](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/nested/DemoLambda.java)]{.bsp}
+[Demo: nested.DemoLambda]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/nested/DemoLambda.java"}
 
 
 ## Syntax für Lambdas

--- a/markdown/modern-java/methodreferences.md
+++ b/markdown/modern-java/methodreferences.md
@@ -145,7 +145,7 @@ public class Studi {
 }
 ```
 
-[Demo: [methodreferences.DemoStaticMethodReference](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/methodreferences/DemoStaticMethodReference.java)]{.bsp}
+[Demo: methodreferences.DemoStaticMethodReference]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/methodreferences/DemoStaticMethodReference.java"}
 
 ::: notes
 `Collections.sort()` erwartet in diesem Szenario als zweiten Parameter eine Instanz von
@@ -180,7 +180,7 @@ public class Studi {
 }
 ```
 
-[Demo: [methodreferences.DemoInstanceMethodReferenceObject](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/methodreferences/DemoInstanceMethodReferenceObject.java)]{.bsp}
+[Demo: methodreferences.DemoInstanceMethodReferenceObject]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/methodreferences/DemoInstanceMethodReferenceObject.java"}
 
 ::: notes
 `Collections.sort()` erwartet in diesem Szenario als zweites Argument wieder eine Instanz
@@ -214,7 +214,7 @@ public class Studi {
 }
 ```
 
-[Demo: [methodreferences.DemoInstanceMethodReferenceType](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/methodreferences/DemoInstanceMethodReferenceType.java)]{.bsp}
+[Demo: methodreferences.DemoInstanceMethodReferenceType]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/methodreferences/DemoInstanceMethodReferenceType.java"}
 
 ::: notes
 `Collections.sort()` erwartet in diesem Szenario als zweites Argument wieder eine Instanz
@@ -258,7 +258,7 @@ Thread t2 = new Thread(() -> System.out.println("t2: wuppie"));
 Thread t3 = new Thread(ThreadStarter::wuppie);
 ```
 
-[Beispiel: [methodreferences.ThreadStarter](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/methodreferences/ThreadStarter.java)]{.bsp}
+[Beispiel: methodreferences.ThreadStarter]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/methodreferences/ThreadStarter.java"}
 
 
 ## Ausblick: Datenstrukturen als Streams
@@ -282,7 +282,7 @@ List<Integer> wordLengths = words.stream()
         .collect(toList());
 ```
 
-[Beispiel: [methodreferences.CollectionStreams](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/methodreferences/CollectionStreams.java)]{.bsp}
+[Beispiel: methodreferences.CollectionStreams]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/methodreferences/CollectionStreams.java"}
 
 ::: notes
 *   Collections können als Datenstrom betrachtet werden: `stream()`

--- a/markdown/modern-java/optional.md
+++ b/markdown/modern-java/optional.md
@@ -226,7 +226,7 @@ _deprecated_.
 _Anmerkung_: Da `getBestStudi()` eine `NullPointerException` werfen kann, sollte der
 Aufruf möglicherweise in ein `try/catch` verpackt werden. Dito für `orElseThrow()`.
 
-[Beispiel: [optional.traditional.Demo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/optional/traditional/Demo.java)]{.bsp}
+[Beispiel: optional.traditional.Demo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/optional/traditional/Demo.java"}
 :::
 
 
@@ -253,7 +253,7 @@ public static void main(String... args) {
 ```
 
 ::: notes
-[Beispiel: [optional.streams.Demo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/optional/streams/Demo.java)]{.bsp}
+[Beispiel: optional.streams.Demo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/optional/streams/Demo.java"}
 
 Im Beispiel wird in `getBestStudi()` die Sammlung als Stream betrachtet, über die
 Methode `sorted()` und den Lamda-Ausdruck für den `Comparator` sortiert ("falsch"

--- a/markdown/modern-java/stream-api.md
+++ b/markdown/modern-java/stream-api.md
@@ -382,7 +382,7 @@ laufen lassen und eine `Collection` erzeugen lassen:
 Die ist nur die sprichwörtliche "Spitze des Eisbergs"! Es gibt viele weitere Möglichkeiten, sowohl
 bei den intermediären als auch den terminalen Operationen. Schauen Sie in die Dokumentation!
 
-[Demo: [streams.Demo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/streams/Demo.java)]{.bsp}
+[Demo: streams.Demo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/modern-java/src/streams/Demo.java"}
 :::
 
 

--- a/markdown/org/syllabus.md
+++ b/markdown/org/syllabus.md
@@ -55,7 +55,7 @@ und pflegen können:
     *   Zusammenarbeit in Teams: Verwaltung von Software und Workflows
 :::
 
-[Warum ist *guter Code* wichtig?]{.bsp}
+[Warum ist guter Code wichtig?]{.bsp}
 
 [=> Guter Code ist vor allem wichtig [für den Entwickler]{.alert}!]{.notes}
 

--- a/markdown/pattern/factory-method.md
+++ b/markdown/pattern/factory-method.md
@@ -64,7 +64,7 @@ fhmedia:
 Implementieren Sie eine Ticket-App, die verschiedene Tickets mit
 Hilfe des Factory-Method Entwurfsmusters generiert.
 
-[UML; Konsole: [factory.FactoryBeispiel](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/factory/FactoryBeispiel.java)]{.bsp}
+[UML; Konsole: factory.FactoryBeispiel]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/factory/FactoryBeispiel.java"}
 
 
 ## Wrap-Up

--- a/markdown/pattern/observer.md
+++ b/markdown/pattern/observer.md
@@ -78,7 +78,7 @@ Zur Benachrichtigung der registrierten Objekte brauchen diese eine geeignete Met
 die traditionell `update()` genannt wird.
 :::
 
-[Demo: [observer](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/observer/)]{.bsp}
+[Demo: observer]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/observer/"}
 
 
 ## Observer-Pattern verallgemeinert

--- a/markdown/pattern/singleton.md
+++ b/markdown/pattern/singleton.md
@@ -87,7 +87,7 @@ public class SingletonEager {
 }
 ```
 
-[Beispiel: [singleton.SingletonEager](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/singleton/SingletonEager.java)]{.bsp}
+[Beispiel: singleton.SingletonEager]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/singleton/SingletonEager.java"}
 
 
 ## Umsetzung: "Lazy" Singleton Pattern
@@ -116,7 +116,7 @@ public class SingletonLazy {
 }
 ```
 
-[Beispiel: [singleton.SingletonLazy](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/singleton/SingletonLazy.java)]{.bsp}
+[Beispiel: singleton.SingletonLazy]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/singleton/SingletonLazy.java"}
 
 
 ## Vorsicht!

--- a/markdown/pattern/strategy.md
+++ b/markdown/pattern/strategy.md
@@ -144,7 +144,7 @@ public class Studi {
 }
 ```
 
-[Konsole [strategy.SortDefault](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/strategy/SortDefault.java), [strategy.SortOwnCrit](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/strategy/SortOwnCrit.java)]{.bsp}
+[Konsole strategy.SortDefault, strategy.SortOwnCrit]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/strategy/"}
 
 _Anmerkung_:
 Die Interfaces `Comparable` und `Comparator` und deren Nutzung wurde(n) in
@@ -180,7 +180,7 @@ Implementieren Sie das Strategie-Muster für eine Übersetzungsfunktion:
 ![](images/translator.png){width="80%"}
 :::
 
-[Konsole [strategy.TranslatorExample](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/strategy/TranslatorExample.java)]{.bsp}
+[Konsole strategy.TranslatorExample]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/strategy/TranslatorExample.java"}
 
 
 ## Wrap-Up

--- a/markdown/pattern/visitor.md
+++ b/markdown/pattern/visitor.md
@@ -221,7 +221,7 @@ Das fängt an, sich zu wiederholen. Wir implementieren immer wieder ähnliche St
 mit denen wir diesen Parsetree traversieren ... Und wir müssen für _jede_ Erweiterung
 immer _alle_ Expression-Klassen anpassen!
 
-[Beispiel: [direct.DemoExpr](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/visitor/direct/DemoExpr.java)]{.bsp}
+[Beispiel: direct.DemoExpr]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/visitor/direct/DemoExpr.java"}
 :::
 
 \vfill
@@ -354,9 +354,9 @@ von Datenstrukturen ist diese Variante oft von Vorteil, da man hier unterschiedl
 Traversierungsarten haben möchte (Breitensuche vs. Tiefensuche, Pre-Order vs. Inorder vs.
 Post-Order, ...) und diese elegant in den Visitor verlagern kann.
 
-[Beispiel Traversierung intern (in den Knotenklassen): [visitor.visit.intrav.DemoExpr](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/visitor/visit/intrav/DemoExpr.java)]{.bsp}
+[Beispiel Traversierung intern (in den Knotenklassen): visitor.visit.intrav.DemoExpr]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/visitor/visit/intrav/DemoExpr.java"}
 
-[Beispiel Traversierung extern (im Visitor): [visitor.visit.extrav.DemoExpr](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/visitor/visit/extrav/DemoExpr.java)]{.bsp}
+[Beispiel Traversierung extern (im Visitor): visitor.visit.extrav.DemoExpr]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/visitor/visit/extrav/DemoExpr.java"}
 
 ### (Double-) Dispatch
 
@@ -402,7 +402,7 @@ implementieren.
 
 ![](images/parsetree_visitor_uml.png)
 
-[Demo: [visitor.visit.extrav.DemoExpr](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/visitor/visit/extrav/DemoExpr.java)]{.bsp}
+[Demo: visitor.visit.extrav.DemoExpr]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/pattern/src/visitor/visit/extrav/DemoExpr.java"}
 
 
 ## Wrap-Up

--- a/markdown/testing/junit-basics.md
+++ b/markdown/testing/junit-basics.md
@@ -82,7 +82,7 @@ void fail();
     *   Test wird abgebrochen, wenn Annahme nicht erfüllt
     *   Prüfen von Vorbedingungen: Ist der Test hier ausführbar/anwendbar?
 
-[Beispiel: [junit4.TestAssume](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/junit4/TestAssume.java)]{.bsp}
+[Beispiel: junit4.TestAssume]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/junit4/TestAssume.java"}
 
 
 ## Setup und Teardown: Testübergreifende Konfiguration
@@ -405,7 +405,7 @@ public class SumTestParameters {
 ```
 :::::::::
 
-[Beispiel: [junit4.SumTestConstructor](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/junit4/SumTestConstructor.java), [junit4.SumTestParameters](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/junit4/SumTestParameters.java)]{.bsp}
+[Beispiel: junit4.SumTestConstructor, junit4.SumTestParameters]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/junit4/"}
 
 
 ::: notes
@@ -432,7 +432,7 @@ oder Methoden (`@MethodSource`) angeben.
 *Hinweis*: Parametrisierte Tests werden in JUnit 5 derzeit noch als "*experimentell*"
 angesehen!
 
-[Beispiel: [junit5.TestValueSource](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/junit5/TestValueSource.java), [junit5.TestMethodSource](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/junit5/TestMethodSource.java)]{.bsp}
+[Beispiel: junit5.TestValueSource, junit5.TestMethodSource]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/junit5/"}
 :::
 
 

--- a/markdown/testing/mockito.md
+++ b/markdown/testing/mockito.md
@@ -232,7 +232,7 @@ des LSF ändert, muss auch der Stub nachgezogen werden).
 Wenn man im Test andere Antworten braucht, müsste man einen weiteren Stub anlegen ...
 :::
 
-[Demo [fhb.StudiStubTest](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/fhb/StudiStubTest.java)]{.bsp}
+[Demo fhb.StudiStubTest]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/fhb/StudiStubTest.java"}
 
 
 ## Mockito: Mocking von ganzen Klassen
@@ -283,7 +283,7 @@ Dies kann man in weiten Grenzen flexibel anpassen.
 Mit Hilfe der Argument-Matcher `anyString()` wird jedes String-Argument akzeptiert.
 :::
 
-[Demo [fhb.StudiMockTest](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/fhb/StudiMockTest.java)]{.bsp}
+[Demo fhb.StudiMockTest]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/fhb/StudiMockTest.java"}
 
 
 ## Mockito: Spy = Wrapper um ein Objekt
@@ -336,7 +336,7 @@ Wenn man die Methoden nicht mit einem partiellen Mock überschreibt, dann wird e
 Auch hier können Argument-Matcher wie `anyString()` eingesetzt werden.
 :::
 
-[Demo [fhb.StudiSpyTest](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/fhb/StudiSpyTest.java)]{.bsp}
+[Demo fhb.StudiSpyTest]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/fhb/StudiSpyTest.java"}
 
 
 ## Wurde eine Methode aufgerufen?
@@ -397,7 +397,7 @@ Mit `InOrder` lassen sich Aufrufe auf einem Mock/Spy oder auch auf verschiedenen
 Reihenfolge bringen und so überprüfen.
 :::
 
-[Demo [fhb.VerifyTest](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/fhb/VerifyTest.java)]{.bsp}
+[Demo fhb.VerifyTest]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/fhb/VerifyTest.java"}
 
 
 ## Fangen von Argumenten
@@ -445,7 +445,7 @@ Argumente in gemockten Methoden zu reagieren. Schauen Sie sich dazu die Javadoc
 von [Mockito](https://javadoc.io/doc/org.mockito/mockito-core/) an.
 :::
 
-[Demo [fhb.MatcherTest](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/fhb/MatcherTest.java)]{.bsp}
+[Demo fhb.MatcherTest]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/fhb/MatcherTest.java"}
 
 
 ## Ausblick: PowerMock
@@ -471,7 +471,7 @@ Mockito sehr mächtig, aber unterstützt (u.a.) keine
 [\@jedi101](https://github.com/jedi101).
 
 
-[Demo: [WuppiWarenlager (wuppie.stub)](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/wuppie/stub/))]{.bsp}
+[Demo: WuppiWarenlager (wuppie.stub)]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/wuppie/stub/"}
 
 Bei dem gezeigten Beispiel unseres `WuppiStores` sieht man, dass dieser
 normalerweise von einem fertigen Warenlager die Wuppis beziehen möchte. Da
@@ -497,7 +497,7 @@ Aber es gibt da einen Ausweg. Wenn es komplexer wird, verwenden wir Mocks.
 
 Bislang haben wir noch keinen Gebrauch von Mockito gemacht. Das ändern wir nun.
 
-[Demo: [WuppiWarenlager (wuppie.mock)](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/wuppie/mock/))]{.bsp}
+[Demo: WuppiWarenlager (wuppie.mock)]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/wuppie/mock/"}
 
 Wie in diesem Beispiel gezeigt, müssen wir nun keinen Stub mehr von Hand
 erstellen, sondern überlassen dies Mockito.
@@ -544,7 +544,7 @@ Und genau dafür bietet Mockito eine Funktion: der sogenannte "Spy".
 Dieser Spion erlaubt es uns nun zusätzlich das Verhalten zu testen. Das geht in
 die Richtung von [BDD - Behavior Driven Development](https://de.wikipedia.org/wiki/Behavior_Driven_Development).
 
-[Demo: [WuppiWarenlager (wuppie.spy)](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/wuppie/spy/))]{.bsp}
+[Demo: WuppiWarenlager (wuppie.spy)]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/wuppie/spy/"}
 
 ```java
 // Spion erstellen, der unser wuppiWarenlager überwacht.
@@ -689,7 +689,7 @@ public void testVerify_InteraktionenMitHilfeDesArgumentCaptor() {
 }
 ```
 
-[Demo: [WuppiWarenlager (wuppie.verify)](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/wuppie/verify/))]{.bsp}
+[Demo: WuppiWarenlager (wuppie.verify)]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/testing/src/mockito/src/test/java/wuppie/verify/"}
 :::::::::
 
 

--- a/markdown/testing/testcases.md
+++ b/markdown/testing/testcases.md
@@ -111,7 +111,7 @@ Beispiel: Zu testende Methode mit Eingabewert _x_, der zw. 10 und 100 liegen sol
 
 *   Unterscheidung gültige und ungültige ÄK
 
-[[Beispiel: Eingabeparameter _x_ zw. 10 und 100]{.bsp}]{.slides}
+[[Beispiel: Eingabeparameter x zw. 10 und 100]{.bsp}]{.slides}
 
 
 ::::::::: notes
@@ -258,7 +258,7 @@ werden (mit zufälligen Werten) aus gültigen ÄK aufgefüllt, um mögliche Gren
 nicht zu überlagern.**
 :::
 
-[[Beispiel: Eingabeparameter _x_ zw. 10 und 100]{.bsp}]{.slides}
+[[Beispiel: Eingabeparameter x zw. 10 und 100]{.bsp}]{.slides}
 
 
 ## GW: Beispiel: Eingabewert _x_ soll zw. 10 und 100 liegen

--- a/markdown/threads/highlevel.md
+++ b/markdown/threads/highlevel.md
@@ -118,7 +118,7 @@ Nachteile:
     `finally`-Block!
 :::
 
-[Demo: [lock.*](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/lock/)]{.bsp}
+[Demo: lock.*]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/lock/"}
 
 
 ## Thread-Management: Executor-Interface und Thread-Pools
@@ -186,7 +186,7 @@ pool.execute(x);    // x.start()
 pool.shutdown();    // Feierabend :)
 ```
 
-[Demo: [executor.ExecutorDemo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/executor/ExecutorDemo.java)]{.bsp}
+[Demo: executor.ExecutorDemo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/executor/ExecutorDemo.java"}
 
 
 ::::::::: notes
@@ -246,7 +246,7 @@ public class RecursiveTask extends ForkJoinTask<V> {
 }
 ```
 
-[Demo: [forkjoin.ForkJoin](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/forkjoin/ForkJoin.java)]{.bsp}
+[Demo: forkjoin.ForkJoin]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/forkjoin/ForkJoin.java"}
 
 
 ## Swing und Threads
@@ -288,7 +288,7 @@ public class RecursiveTask extends ForkJoinTask<V> {
     *   `V` Typ für Zwischenergebnisse
 :::
 
-[Demo: [misc.SwingWorkerDemo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/misc/SwingWorkerDemo.java)]{.bsp}
+[Demo: misc.SwingWorkerDemo]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/misc/SwingWorkerDemo.java"}
 
 
 ## Letzte Worte :-)

--- a/markdown/threads/intro.md
+++ b/markdown/threads/intro.md
@@ -76,7 +76,7 @@ fhmedia:
 Wert 42 ausprobieren (ist zeitlich ganz gut)
 -->
 
-[Demo: [misc.SwingWorkerDemo](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/misc/SwingWorkerDemo.java)  (GUI ausprobieren)]{.bsp}
+[Demo: misc.SwingWorkerDemo (GUI ausprobieren)]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/misc/SwingWorkerDemo.java"}
 
 
 ::: notes
@@ -112,7 +112,7 @@ public class Traditional {
 }
 ```
 
-[Demo: [intro.Traditional](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/intro/Traditional.java)]{.bsp}
+[Demo: intro.Traditional]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/intro/Traditional.java"}
 
 
 ::: notes
@@ -154,7 +154,7 @@ public class Threaded extends Thread {
 }
 ```
 
-[Demo: [intro.Threaded](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/intro/Threaded.java)]{.bsp}
+[Demo: intro.Threaded]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/intro/Threaded.java"}
 
 
 ## Erzeugen von Threads
@@ -166,7 +166,7 @@ public class Threaded extends Thread {
 *   Methode `run()` implementieren, aber nicht aufrufen
 *   Methode `start()` aufrufen, aber (i.d.R.) nicht implementieren
 
-[Demo: [creation.*](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/creation/)]{.bsp}
+[Demo: creation.*]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/creation/"}
 
 ::: notes
 ### Ableiten von _Thread_
@@ -278,7 +278,7 @@ besprochen.
 
 \vspace{24mm}
 
-[Demo: [intro.Join](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/intro/Join.java)]{.bsp}
+[Demo: intro.Join]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/intro/Join.java"}
 
 
 ## Wrap-Up

--- a/markdown/threads/synchronisation.md
+++ b/markdown/threads/synchronisation.md
@@ -92,7 +92,7 @@ public class Teaser implements Runnable {
 }
 ```
 
-[Demo: [synchronised.Teaser](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/synchronised/Teaser.java)]{.bsp}
+[Demo: synchronised.Teaser]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/synchronised/Teaser.java"}
 
 
 ## Zugriff auf gemeinsame Ressourcen: Mehrseitige Synchronisierung
@@ -140,7 +140,7 @@ geschützten Bereich einschließen und als Sperr-Objekt das eigene Objekt (`this
     }
 ```
 
-[Demo: [synchronised.ObjSync](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/synchronised/ObjSync.java)]{.bsp}
+[Demo: synchronised.ObjSync]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/synchronised/ObjSync.java"}
 
 
 ## Synchronisierte Methoden
@@ -190,7 +190,7 @@ Die Methode `incrVal()` könnte entsprechend so umgeschrieben werden:
     }
 ```
 
-[Demo: [synchronised.MethodSync](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/synchronised/MethodSync.java)]{.bsp}
+[Demo: synchronised.MethodSync]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/synchronised/MethodSync.java"}
 
 
 ## Probleme bei der (mehrseitigen) Synchronisierung: Deadlocks
@@ -238,7 +238,7 @@ holen, den aber aktuell der erste Thread hält.
 Und schon geht's nicht mehr weiter :-)
 :::
 
-[Demo: [synchronised.Deadlock](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/synchronised/Deadlock.java)]{.bsp}
+[Demo: synchronised.Deadlock]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/synchronised/Deadlock.java"}
 
 
 ## Warten auf andere Threads: Einseitige Synchronisierung
@@ -322,7 +322,7 @@ Und schon geht's nicht mehr weiter :-)
 => Geht nur innerhalb der `synchronized`-Anweisung für das Synchronisations-Objekt!
 :::
 
-[Demo: [synchronised.Staffel](https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/synchronised/Staffel.java)]{.bsp}
+[Demo: synchronised.Staffel]{.bsp href="https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/threads/src/synchronised/Staffel.java"}
 
 
 ## Wrap-Up


### PR DESCRIPTION
Ersetze in allen `.bsp`-Spans die URLs in den Texten und nutze stattdessen das neue Key/Value-Paar `href`. 

Hintergrund: Markdown im Span wird als Markdown-Content an den `button`-Shortcode aus Hugo-Relearn-Theme weitergereicht, dort auch noch korrekt verarbeitet - aber Sonderzeichen werden in Hugo-Relearn-Theme 5.12.2 escaped. Das sorgt dann dafür, dass der Browser den HTML-Code anzeigt, aber nicht rendert.

fixes #620 (zusammen mit https://github.com/cagix/pandoc-lecture/pull/27)