### PR TITLE
[Aufgaben ] add neue Aufgaben group_item/schatzkiste und group_item/lockpicking

### DIFF
--- a/markdown/assignments/group_loot/freie_aufgabe.md
+++ b/markdown/assignments/group_loot/freie_aufgabe.md
@@ -3,7 +3,7 @@ archetype: assignment
 title: "Freie Aufgabe"
 author: "André Matutat (FH Bielefeld)"
 points: 10
-weight: 8
+weight: 9
 
 hidden: true
 ---

--- a/markdown/assignments/group_loot/lockpicking.md
+++ b/markdown/assignments/group_loot/lockpicking.md
@@ -10,7 +10,7 @@ hidden: true
 
 ## Ziel
 
-In dieser Aufgabe implementieren Sie eine [Mini-Spiel](https://de.wikipedia.org/wiki/Minispiel), um verschlossene Schatzkiste zu knacken. 
+In dieser Aufgabe implementieren Sie ein [Mini-Spiel](https://de.wikipedia.org/wiki/Minispiel), um verschlossene Schatzkiste zu knacken. 
 
 ## Voraussetzung
 
@@ -22,4 +22,4 @@ In den Vorgaben finden Sie die Implementierung einer [Schatzkiste](https://githu
 
 Implementieren Sie eine Möglichkeit, dass Schatzkisten verschlossen sein können und nur mit einen bestimmten Schlüssel geöffnet werden können. 
 
-Recherchieren Sie nach "Lockpicking-Minigames" aus anderen Spielen und Implementieren Sie eine Umsetzung für Ihr Spiel. Wenn der Spieler nicht den passenden Schlüssel zu einer SChatzkiste gefunden hat, soll er die Schatzkiste durch das Lösen des Mini-Spiels öffnen können. 
+Recherchieren Sie nach "Lockpicking-Minigames" aus anderen Spielen und implementieren Sie eine Umsetzung für Ihr Spiel. Wenn der Spieler nicht den passenden Schlüssel zu einer Schatzkiste gefunden hat, soll er die Schatzkiste durch das Lösen des Mini-Spiels öffnen können. 

--- a/markdown/assignments/group_loot/lockpicking.md
+++ b/markdown/assignments/group_loot/lockpicking.md
@@ -1,0 +1,25 @@
+---
+archetype: assignment
+title: "Lockpicking"
+author: "André Matutat (FH Bielefeld)"
+points: 10
+weight: 7
+
+hidden: true
+---
+
+## Ziel
+
+In dieser Aufgabe implementieren Sie eine [Mini-Spiel](https://de.wikipedia.org/wiki/Minispiel), um verschlossene Schatzkiste zu knacken. 
+
+## Voraussetzung
+
+Um diese Aufgabe lösen zu können, müssen Sie vorher `["Item"]({{< ref "/assignments/item" >}})`{=markdown} gelöst haben.
+
+## Lockpicking
+
+In den Vorgaben finden Sie die Implementierung einer [Schatzkiste](https://github.com/Programmiermethoden/Dungeon/blob/master/game/src/ecs/entities/Chest.java). Führen Sie eine Codeanlyse durch und erklären Sie die Funktionalität.
+
+Implementieren Sie eine Möglichkeit, dass Schatzkisten verschlossen sein können und nur mit einen bestimmten Schlüssel geöffnet werden können. 
+
+Recherchieren Sie nach "Lockpicking-Minigames" aus anderen Spielen und Implementieren Sie eine Umsetzung für Ihr Spiel. Wenn der Spieler nicht den passenden Schlüssel zu einer SChatzkiste gefunden hat, soll er die Schatzkiste durch das Lösen des Mini-Spiels öffnen können. 

--- a/markdown/assignments/group_loot/schatzkiste.md
+++ b/markdown/assignments/group_loot/schatzkiste.md
@@ -10,7 +10,7 @@ hidden: true
 
 ## Ziel
 
-In dieser Aufgabe implementieren Sie eine Monster-Schatzkisten, die der Spieler im Level finden und plündern kann.
+In dieser Aufgabe implementieren Sie eine Monster-Schatzkiste, die der Spieler im Level finden und plündern kann. Vor dem Plündern muss die Kiste aber besiegt werden!
 
 ## Voraussetzung
 
@@ -20,7 +20,6 @@ Um diese Aufgabe lösen zu können, müssen Sie vorher `["Monster"]({{< ref "/as
 
 In den Vorgaben finden Sie die Implementierung einer [Schatzkiste](https://github.com/Programmiermethoden/Dungeon/blob/master/game/src/ecs/entities/Chest.java). Führen Sie eine Codeanlyse durch und erklären Sie die Funktionalität. 
 
-Konzeptionieren und Implementieren Sie nun einen neuen Monster Typen, die "Monster-Schatzkiste".
-Dieses Monster soll aussehen wie eine Schatzkiste, greift den Spiler jedoch beim versuch sie zu plündern an. 
-Wenn der Spieler das Monster besiegt hat, soll das Schatzkisten-Monster sich wie eine Schatzkiste verhalten und seine Beute preisgeben. 
-
+Konzipieren und implementieren Sie nun die "Monster-Schatzkiste" als einen neuen Monster-Typ.
+Dieses Monster soll aussehen wie eine Schatzkiste, greift den Spieler jedoch beim Versuch sie zu plündern an. 
+Wenn der Spieler das Monster besiegt hat, soll das Schatzkisten-Monster sich wie eine normale Schatzkiste verhalten und seine Beute preisgeben. 

--- a/markdown/assignments/group_loot/schatzkiste.md
+++ b/markdown/assignments/group_loot/schatzkiste.md
@@ -1,8 +1,8 @@
 ---
 archetype: assignment
-title: "Schatzkisten"
+title: "Monster-Schatzkisten"
 author: "André Matutat (FH Bielefeld)"
-points: 1
+points: 5
 weight: 5
 
 hidden: true
@@ -10,16 +10,17 @@ hidden: true
 
 ## Ziel
 
-In dieser Aufgabe implementieren Sie Schatzkisten, die der Spieler im Level finden und plündern kann.
+In dieser Aufgabe implementieren Sie eine Monster-Schatzkisten, die der Spieler im Level finden und plündern kann.
 
 ## Voraussetzung
 
-Um diese Aufgabe lösen zu können, müssen Sie vorher `["Inventar"]({{< ref "/assignments/pool_dungeon/group_a/inventar_text_based" >}})`{=markdown} und `["Item"]({{< ref "/assignments/pool_dungeon/group_c/item" >}})`{=markdown} gelöst haben.
+Um diese Aufgabe lösen zu können, müssen Sie vorher `["Monster"]({{< ref "/assignments/group_monster/monster" >}})`{=markdown} und `["Item"]({{< ref "/assignments/item" >}})`{=markdown} gelöst haben.
 
-## Schatzkiste
+## Monster-Schatzkiste
 
-Implementieren Sie Schatzkisten, die im Dungeon verteilt werden und von den Spielern geöffnet ("aktiviert") werden können. Die Kisten sind zunächst geschlossen und können durch eine (neue) Aktion des Helden geöffnet werden, sofern er in ausreichender Nähe ist. Erst dann ist der Inhalt sichtbar und für den Helden zugreifbar.
+In den Vorgaben finden Sie die Implementierung einer [Schatzkiste](https://github.com/Programmiermethoden/Dungeon/blob/master/game/src/ecs/entities/Chest.java). Führen Sie eine Codeanlyse durch und erklären Sie die Funktionalität. 
 
-Schatzkisten beinhalten (zufällige) Items, die der Spieler aufsammeln kann. Schatzkisten haben damit auch ein Inventar.
+Konzeptionieren und Implementieren Sie nun einen neuen Monster Typen, die "Monster-Schatzkiste".
+Dieses Monster soll aussehen wie eine Schatzkiste, greift den Spiler jedoch beim versuch sie zu plündern an. 
+Wenn der Spieler das Monster besiegt hat, soll das Schatzkisten-Monster sich wie eine Schatzkiste verhalten und seine Beute preisgeben. 
 
-Schatzkisten sollen nur in der Nähe des Spielers aktivierbar sein.

--- a/markdown/assignments/group_loot/testen.md
+++ b/markdown/assignments/group_loot/testen.md
@@ -3,7 +3,7 @@ archetype: assignment
 title: "JUnit Group C"
 author: "André Matutat (FH Bielefeld)"
 points: 5
-weight: 7
+weight: 8
 
 hidden: true
 ---


### PR DESCRIPTION
fixes #651 

Führt zwei neue Aufgaben ein.
1. Erweitern der vorhanden Schatzkiste, um sie zu einer Monter-Schatzkiste zu machen
2. Implementieren eines Lockpicking-Minigames

- anpassen der weights 
- Baut auf #642 