### PR TITLE
[Schedule] Gastvortrag zu JUnit/Mocking in der Praxis

### DIFF
--- a/data/schedule.yaml
+++ b/data/schedule.yaml
@@ -61,6 +61,8 @@
         -   topic: "/testing/testcases"
         -   topic: "/testing/mockito"
         -   topic: "/pattern/command"
+    misc_lecture:
+        -   notes: ">> Gastvortrag zu JUnit/Mocking in der Praxis von Daniel Rosowski (Smartsquare GmbH, Bielefeld)"
     assignment:
         -   topic: "/assignments"
             due: "Di, 09.05., 09 Uhr, ILIAS"


### PR DESCRIPTION
Gastvortrag zu JUnit/Mocking in der Praxis von Daniel in KW19, also konkret Freitag, 12.05., 16:30 - 18:00 Uhr

fixes #656