### PR TITLE
[ORG] Clean-up: Schedule, Grading, FAQ

### DIFF
--- a/data/schedule.yaml
+++ b/data/schedule.yaml
@@ -26,7 +26,7 @@
         -   topic: "/pattern/strategy"
     assignment:
         -   topic: "/assignments"
-            due: "Do, 20.04., 08 Uhr; Peer-Feedback Fr, 21.04., 08 Uhr"
+            due: "Do, 20.04., 08 Uhr; Peer-Feedback: Fr, 21.04., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 1: Abgabe und Vorstellung Konzept"
 
@@ -38,7 +38,7 @@
         -   topic: "/modern-java/methodreferences"
     assignment:
         -   topic: "/assignments"
-            due: "Do, 27.04., 08 Uhr; Peer-Feedback Fr, 28.04., 08 Uhr"
+            due: "Do, 27.04., 08 Uhr; Peer-Feedback: Fr, 28.04., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 1: Abgabe und Vorstellung Code"
 
@@ -50,7 +50,7 @@
         -   topic: "/pattern/type-object"
     assignment:
         -   topic: "/assignments"
-            due: "Do, 04.05., 08 Uhr; Peer-Feedback Fr, 05.05., 08 Uhr"
+            due: "Do, 04.05., 08 Uhr; Peer-Feedback: Fr, 05.05., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 2: Abgabe und Vorstellung Konzept"
 
@@ -65,7 +65,7 @@
         -   notes: ">> Gastvortrag zu JUnit/Mocking in der Praxis von Daniel Rosowski (Smartsquare GmbH, Bielefeld)"
     assignment:
         -   topic: "/assignments"
-            due: "Do, 11.05., 08 Uhr; Peer-Feedback Fr, 12.05., 08 Uhr"
+            due: "Do, 11.05., 08 Uhr; Peer-Feedback: Fr, 12.05., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 2: Abgabe und Vorstellung Code"
 
@@ -77,7 +77,7 @@
         -   topic: "/building/ci"
     assignment:
         -   topic: "/assignments"
-            due: "Do, 18.05., 08 Uhr; Peer-Feedback Fr, 19.05., 08 Uhr"
+            due: "Do, 18.05., 08 Uhr; Peer-Feedback: Fr, 19.05., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 3: Abgabe und Vorstellung Konzept"
 
@@ -90,7 +90,7 @@
         -   topic: "/building/docker"
     assignment:
         -   topic: "/assignments"
-            due: "Do, 25.05., 08 Uhr; Peer-Feedback Fr, 26.05., 08 Uhr"
+            due: "Do, 25.05., 08 Uhr; Peer-Feedback: Fr, 26.05., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 3: Abgabe und Vorstellung Code"
 
@@ -103,7 +103,7 @@
         -   topic: "/git/worktree"
     assignment:
         -   topic: "/assignments"
-            due: "Do, 01.06., 08 Uhr; Peer-Feedback Fr, 02.06., 08 Uhr"
+            due: "Do, 01.06., 08 Uhr; Peer-Feedback: Fr, 02.06., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 4: Abgabe und Vorstellung Konzept"
 
@@ -115,7 +115,7 @@
         -   topic: "/pattern/singleton"
     assignment:
         -   topic: "/assignments"
-            due: "Do, 08.06., 08 Uhr; Peer-Feedback Fr, 09.06., 08 Uhr"
+            due: "Do, 08.06., 08 Uhr; Peer-Feedback: Fr, 09.06., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 4: Abgabe und Vorstellung Code"
 
@@ -129,7 +129,7 @@
         -   topic: "/pattern/dependency"
     assignment:
         -   topic: "/assignments"
-            due: "Do, 15.06., 08 Uhr; Peer-Feedback Fr, 16.06., 08 Uhr"
+            due: "Do, 15.06., 08 Uhr; Peer-Feedback: Fr, 16.06., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 5: Abgabe und Vorstellung Konzept"
 
@@ -142,7 +142,7 @@
         -   topic: "/pattern/template-method"
     assignment:
         -   topic: "/assignments"
-            due: "Do, 22.06., 08 Uhr; Peer-Feedback Fr, 23.06., 08 Uhr"
+            due: "Do, 22.06., 08 Uhr; Peer-Feedback: Fr, 23.06., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 5: Abgabe und Vorstellung Code"
 

--- a/data/schedule.yaml
+++ b/data/schedule.yaml
@@ -26,7 +26,7 @@
         -   topic: "/pattern/strategy"
     assignment:
         -   topic: "/assignments"
-            due: "Di, 18.04., 09 Uhr, ILIAS"
+            due: "Do, 20.04., 08 Uhr; Peer-Feedback Fr, 21.04., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 1: Abgabe und Vorstellung Konzept"
 
@@ -38,7 +38,7 @@
         -   topic: "/modern-java/methodreferences"
     assignment:
         -   topic: "/assignments"
-            due: "Di, 25.04., 09 Uhr, ILIAS"
+            due: "Do, 27.04., 08 Uhr; Peer-Feedback Fr, 28.04., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 1: Abgabe und Vorstellung Code"
 
@@ -50,7 +50,7 @@
         -   topic: "/pattern/type-object"
     assignment:
         -   topic: "/assignments"
-            due: "Di, 02.05., 09 Uhr, ILIAS"
+            due: "Do, 04.05., 08 Uhr; Peer-Feedback Fr, 05.05., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 2: Abgabe und Vorstellung Konzept"
 
@@ -65,7 +65,7 @@
         -   notes: ">> Gastvortrag zu JUnit/Mocking in der Praxis von Daniel Rosowski (Smartsquare GmbH, Bielefeld)"
     assignment:
         -   topic: "/assignments"
-            due: "Di, 09.05., 09 Uhr, ILIAS"
+            due: "Do, 11.05., 08 Uhr; Peer-Feedback Fr, 12.05., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 2: Abgabe und Vorstellung Code"
 
@@ -77,7 +77,7 @@
         -   topic: "/building/ci"
     assignment:
         -   topic: "/assignments"
-            due: "Di, 16.05., 09 Uhr, ILIAS"
+            due: "Do, 18.05., 08 Uhr; Peer-Feedback Fr, 19.05., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 3: Abgabe und Vorstellung Konzept"
 
@@ -90,7 +90,7 @@
         -   topic: "/building/docker"
     assignment:
         -   topic: "/assignments"
-            due: "Di, 23.05., 09 Uhr, ILIAS"
+            due: "Do, 25.05., 08 Uhr; Peer-Feedback Fr, 26.05., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 3: Abgabe und Vorstellung Code"
 
@@ -103,7 +103,7 @@
         -   topic: "/git/worktree"
     assignment:
         -   topic: "/assignments"
-            due: "Di, 30.05., 09 Uhr, ILIAS"
+            due: "Do, 01.06., 08 Uhr; Peer-Feedback Fr, 02.06., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 4: Abgabe und Vorstellung Konzept"
 
@@ -115,7 +115,7 @@
         -   topic: "/pattern/singleton"
     assignment:
         -   topic: "/assignments"
-            due: "Di, 06.06., 09 Uhr, ILIAS"
+            due: "Do, 08.06., 08 Uhr; Peer-Feedback Fr, 09.06., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 4: Abgabe und Vorstellung Code"
 
@@ -129,7 +129,7 @@
         -   topic: "/pattern/dependency"
     assignment:
         -   topic: "/assignments"
-            due: "Di, 13.06., 09 Uhr, ILIAS"
+            due: "Do, 15.06., 08 Uhr; Peer-Feedback Fr, 16.06., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 5: Abgabe und Vorstellung Konzept"
 
@@ -142,7 +142,7 @@
         -   topic: "/pattern/template-method"
     assignment:
         -   topic: "/assignments"
-            due: "Di, 20.06., 09 Uhr, ILIAS"
+            due: "Do, 22.06., 08 Uhr; Peer-Feedback Fr, 23.06., 08 Uhr"
     misc_assignment:
         -   notes: ">> Zyklus 5: Abgabe und Vorstellung Code"
 
@@ -154,6 +154,6 @@
             notes: "Prüfungsvorbereitung (Zoom)"
     assignment:
         -   topic: "/assignments"
-            due: "Fr, 30.06., 09 Uhr, ILIAS"
+            due: "Fr, 30.06., 09 Uhr"
     misc_assignment:
         -   notes: ">> Sondertermin (bei 'nicht bestanden')"

--- a/markdown/_index.md
+++ b/markdown/_index.md
@@ -82,9 +82,9 @@ Weitere empfohlene Literatur siehe `["Ressourcen"]({{< ref "/org/resources" >}})
 
 `{{< schedule >}}`{=markdown}
 
-**Hinweise**: Abgabe der Hausaufgaben jeweils bis Mittwoch 15:00 Uhr im ILIAS. Peer-Feedback
-jeweils bis Donnerstag 15:00 Uhr im ILIAS. Finale Überarbeitung der Hausaufgaben bis zur
-Vorstellung im Praktikum. Vorstellung der Lösungen im jeweiligen Praktikumstermin am Freitag.
+**Hinweise**: Abgabe der Hausaufgaben jeweils bis zur angegebenen Deadline im ILIAS.
+Peer-Feedback jeweils bis zur angegebenen Deadline im ILIAS.
+Vorstellung der Lösungen im jeweiligen nachfolgenden Praktikumstermin.
 
 
 ## Förderungen und Kooperationen

--- a/markdown/_index.md
+++ b/markdown/_index.md
@@ -45,6 +45,8 @@ Durchführung als **Flipped Classroom**: Sitzungen per Zoom (**Zugangsdaten sieh
 *   Gruppe 3: Fr, 10:45 - 12:15 Uhr (online/J104)
 *   Gruppe 4: Fr, 15:00 - 16:30 Uhr (online/J104)
 
+Tutorium: Mo, 16:45 - 17:45 Uhr (online)
+
 **Zugangsdaten siehe [ILIAS]**
 
 [ILIAS]: https://www.fh-bielefeld.de/elearning/goto.php?target=crs_1181185&client_id=FH-Bielefeld

--- a/markdown/org/faq.md
+++ b/markdown/org/faq.md
@@ -88,35 +88,34 @@ In diesem Semester gibt es einen 2-Wochen-Rhythmus im Praktikum.
 ### Erste Woche: Konzeptphase
 
 In der ersten Woche suchen Sie sich die zu bearbeitenden Aufgaben aus (vgl.
-[Auswahl der Übungsaufgaben] in der FAQ) und erstellen ein Lösungskonzept (vgl.
-[Konzeptskizze] in der FAQ). Dieses laden Sie bis zur Deadline als PDF in die
-jeweilige ILIAS-Aufgabe hoch.
+[Auswahl der Übungsaufgaben] in der FAQ) und erstellen im Team ein Lösungskonzept
+(vgl. [Konzeptskizze] in der FAQ).
+
+Die Konzeptskizze laden Sie bis zur Deadline als PDF in die jeweilige ILIAS-Aufgabe
+hoch. Diese Abgabe muss aus technischen Gründen bitte jedes Teammitglied einzeln machen.
 
 Anschließend erfolgt eine Peer-Feedback-Phase. ILIAS weist Ihnen mehrere Abgaben
 zu und Sie haben einen Tag Zeit, um Ihr Feedback im ILIAS abzugeben (vgl.
-[Peer-Feedback: How to Review] in der FAQ).
+[Peer-Feedback: How to Review] in der FAQ). Das Feedback muss wieder einzeln von
+jedem Teammitglied bearbeitet werden.
 
-Am Freitag in der ersten Woche stellen Sie Ihr Konzept im Praktikum vor. Dabei
-ist jedes Teammitglied anwesend und kann Auskunft geben.
+Am Freitag in der ersten Woche stellen Sie im Team Ihr Konzept im Praktikum vor.
+Dabei ist jedes Teammitglied anwesend und kann Auskunft geben.
 
 ### Zweite Woche: Implementierungsphase
 
-Danach treten Sie in die zweite Woche des aktuellen Zyklus ein und setzen Ihr Konzept in
-eine Implementierung um. Diese laden als ZIP-Datei bis zur Deadline als Abgabe in die
-jeweilige ILIAS-Aufgabe hoch.
+Danach treten Sie in die zweite Woche des aktuellen Zyklus ein und setzen im Team Ihr
+Konzept in eine Implementierung um. Diese laden als ZIP-Datei bis zur Deadline als
+Abgabe in die jeweilige ILIAS-Aufgabe hoch. Diese Abgabe muss aus technischen Gründen
+bitte jedes Teammitglied einzeln machen.
 
 Anschließend erfolgt eine erneute Peer-Feedback-Phase. ILIAS weist Ihnen mehrere Abgaben
 zu und Sie haben einen Tag Zeit, um Ihr Feedback im ILIAS abzugeben (vgl.
-[Peer-Feedback: How to Review] in der FAQ).
+[Peer-Feedback: How to Review] in der FAQ). Das Feedback muss wieder einzeln von
+jedem Teammitglied bearbeitet werden.
 
-Am Freitag in der zweiten Woche stellen Sie Ihre Lösung im Praktikum vor. Dabei ist jedes
-Teammitglied anwesend und kann Auskunft geben.
-
-### Überarbeitung nach Feedback
-
-Sie können das Feedback in beiden Wochen nutzen, um Ihre Lösung zu verbessern. Die
-Überarbeitung darf sich aber nur auf die Kritik im Feedback beziehen und ist geeignet
-zu dokumentieren.
+Am Freitag in der zweiten Woche stellen Sie im Team Ihre Lösung im Praktikum vor.
+Dabei ist jedes Teammitglied anwesend und kann Auskunft geben.
 
 [Auswahl der Übungsaufgaben]: #auswahl-der-übungsaufgaben
 [Konzeptskizze]: #konzeptskizze
@@ -125,12 +124,13 @@ zu dokumentieren.
 
 ## Bearbeitung der Übungsaufgaben
 
-Die Übungsaufgaben sollen in 3er-Teams (oder ausnahmsweise in 2er-Teams) bearbeitet
-und gelöst werden. Die Einteilung wird über Etherpads im ILIAS vorgenommen, dabei
-können Sie die Teams selbst bilden.
+Die Übungsaufgaben sollen in 3er-Teams bearbeitet und gelöst werden. Die Einteilung
+wird über Etherpads im ILIAS vorgenommen, dabei können Sie die Teams selbst bilden.
 
 Sie können Ihre Teams gern auch im Semester wechseln, dazu müssen Sie einfach nur den
 Eintrag in den Etherpads im ILIAS anpassen.
+
+In Absprache mit dem Dozenten sind in Ausnahmefällen auch 2er-Teams möglich.
 
 
 ## Auswahl der Übungsaufgaben
@@ -144,6 +144,7 @@ Ausnahme: Die "freien Aufgaben" können Sie gern wiederholt bearbeiten, so lange
 Sie jeweils ein Problem wählen, das nicht bereits in anderen Aufgaben vorkommt.
 
 Sie können pro Zyklus Aufgaben im Umfang von 15 Punkten abgeben/vorstellen.
+(Dazu kommen dann in den Zyklen 3 bis 5 noch je bis zu 5 Punkte für die Codequalität.)
 
 
 ## Bounty-Aufgaben
@@ -195,20 +196,10 @@ und damit keinen Anspruch auf die Bonus-Punkte, die Entscheidung liegt beim Doze
 [Bonus-Punkte: Helfen im Framework]: #bonus-punkte-helfen-im-framework
 
 
-## Workload Praktikum
-
-Pro **Zyklus** sollen Sie Aufgaben für **15 Punkte** bearbeiten.
-
-Sie können auch mehr machen, aber wir limitieren die maximal erreichbare Punktzahl
-hier auf _15 Punkte pro Zyklus_.
-
-Dazu kommen dann in den Zyklen 3 bis 5 noch je bis zu 5 Punkte für die Codequalität.
-
-
 ## Konzeptskizze
 
-In der ersten Woche eines Zyklus suchen Sie sich die Aufgaben aus, die Sie in diesem Zyklus
-bearbeiten wollen und erstellen eine Konzeptskizze für diese Aufgaben.
+In der ersten Woche eines Zyklus suchen Sie sich im Team die Aufgaben aus, die Sie in
+diesem Zyklus bearbeiten wollen und erstellen eine Konzeptskizze für diese Aufgaben.
 
 In der Skizze beschreiben Sie mindestens die folgenden Punkte:
 
@@ -219,7 +210,7 @@ In der Skizze beschreiben Sie mindestens die folgenden Punkte:
 4.  Ansatz und Modellierung: Wie sieht eine erste grobe Modellierung aus, welche Klassen
     und Methoden brauchen Sie? Erstellen Sie hierfür ein UML-Diagramm.
 
-Die Konzeptskizze geben Sie als PDF-Dokument ab.
+Die Konzeptskizze geben Sie als PDF-Dokument ab (jedes Teammitglied einzeln!).
 
 Zur Orientierung stellen wir Ihnen ein [ausgefülltes Beispiel] zur Verfügung. Bitte beachten
 Sie, dass es in diesem Beispiel um eine fikitive Aufgabe im Dungeon geht und dass die gezeigte
@@ -233,11 +224,9 @@ Modellierung nicht konform zur ECS-Struktur des aktuellen Dungeons ist.
 Bitte laden Sie Ihre Lösung als eine **PDF-Datei** (Konzeptphase) oder als ein
 **Zip-Archiv** (Implementierungsphase) in die jeweilige Aufgabe im ILIAS hoch.
 
-Beachten Sie die jeweilige Deadline. Sofern nichts anderes angegeben ist, sollen
-die Lösungen jeweils bis Mittwoch 15:00 Uhr im ILIAS hochgeladen werden.
+Beachten Sie dabei die jeweilige Deadline.
 
-Dabei gibt jedes Team nur **eine gemeinsame Lösung** ab: Eine Person aus dem Team
-lädt die Lösung in das ILIAS und trägt die Teammitglieder mit ein.
+**Wichtig**: Jedes Teammitglied gibt die Lösung selbst ab (einzeln).
 
 _Anmerkung_: Falls Sie mehrere Dateien hochladen wollen, erzeugen Sie bitte vor
 dem Upload lokal ein Zip-Archiv, welches Sie dann per Button "Datei einreichen"
@@ -250,17 +239,18 @@ hochladen" nutzen!
 ## Peer-Feedback: How to Review
 
 Sobald die Abgabefrist für eine Aufgabe abgelaufen ist, verteilt ILIAS automatisch
-an alle, die selbst eine Lösung hochgeladen haben, zufällige Aufforderungen zum
-Review anderer Abgaben.
+an alle, die eine Lösung hochgeladen haben, zufällige Aufforderungen zum Review
+anderer Abgaben.
 
 Sie finden die angeforderten Reviews im ILIAS in der jeweiligen Aufgabe.
 
 ![](images/howtofeedback1.png){width="80%"}
 
-Gehen Sie **nach der Deadline der Aufgabe** (i.d.R. Mittwoch 15 Uhr) und
-**vor der Deadline des Reviews** (i.d.R. Donnerstag 15 Uhr) ins ILIAS in die
-Aufgabe und klicken auf den Button "Feedback geben", um nachzuschauen, wem Sie
-ein Peer-Feedback geben sollen.
+Gehen Sie **nach der Deadline der Aufgabe** und **vor der Deadline des Reviews** ins
+ILIAS in die Aufgabe und klicken auf den Button "Feedback geben", um nachzuschauen,
+wem Sie ein Peer-Feedback geben sollen.
+
+**Wichtig**: Jedes Teammitglied erstellt seine eigenen Reviews (einzeln).
 
 ![](images/howtofeedback2.png){width="80%"}
 
@@ -271,7 +261,6 @@ einzutragen.
 
 ![](images/howtofeedback3.png){width="80%"}
 ![](images/howtofeedback4.png){width="80%"}
-
 
 _Hinweis_: Wenn bei den Review-Fragen mit den "Ja/Nein"-Checkboxen alle Kriterien
 mit "Nein" beantwortet werden mussten, also keine der Checkboxen angehakt werden
@@ -300,8 +289,8 @@ kann und deshalb stets kritisch hinterfragt werden sollte.
 
 ## Vorstellung der Lösungen
 
-Im Praktikum stellen Sie Ihre Lösungen vor und diskutieren darüber und beantworten
-kurze Fragen oder passen ad hoc im Gespräch Ihre Lösung weiter an.
+Im Praktikum stellen Sie im Team Ihre Lösungen vor und diskutieren darüber und
+beantworten kurze Fragen und passen ad hoc im Gespräch Ihre Lösung weiter an.
 
 Die Vorstellung Ihrer Lösung erfolgt mit einem Medium Ihrer Wahl. Sie können zum
 Beispiel Ihren Bildschirm teilen und Ihre Lösung erklären. Sie brauchen nicht extra
@@ -310,11 +299,11 @@ eine Präsentation anfertigen!
 Die Vorstellung der Lösung erfolgt duch alle Teammitglieder. Ohne aktive Teilnahme
 an der Vorstellung gibt es keine Punkte.
 
-Für die Vorstellungen werden individuelle Zeitslots pro Team innerhalb Ihrer Praktikumszeit
-(Stundenplangruppe) vereinbart (siehe Etherpads im ILIAS).
+Für die Vorstellungen werden individuelle Zeitslots pro Team innerhalb Ihrer
+Praktikumszeit (Stundenplangruppe) vereinbart (siehe Etherpads im ILIAS).
 
-Wer nicht an der Vorstellung teilnimmt oder wer zwar anwesend ist, aber nicht auf Fragen
-antworten kann/will, kann leider keine Punkte bekommen.
+Wer nicht an der Vorstellung teilnimmt oder wer zwar anwesend ist, aber nicht auf
+Fragen antworten kann/will, kann leider keine Punkte bekommen.
 
 
 ## Zeitslots für Vorstellung
@@ -323,25 +312,15 @@ Wir werden mit jedem Team einen individuellen Abgabeslot in Ihrer Praktikumsgrup
 vereinbaren, damit Sie im Praktikum zielgerichtet zu Ihrer Abgabe kommen können und
 so längere Wartezeiten vermeiden können.
 
-Dazu gibt es vorbereitete Etherpads im ILIAS, wo Sie sich mit Ihrem Team für einen
+Dazu finden Sie vorbereitete Etherpads im ILIAS, wo Sie sich mit Ihrem Team für einen
 Abgabeslot in ihrer Praktikumszeit/Stundenplangruppe eintragen.
 
-Wenn ein Team mit Mitgliedern aus verschiedenen Stundenplangruppen gebildet wird, dann
+Falls ein Team mit Mitgliedern aus verschiedenen Stundenplangruppen gebildet wird, dann
 tragen Sie sich bitte in dem Praktikumsslot ein, wo die Mehrzahl der Team-Mitglieder
 zugeordnet ist.
 
 
 ## Verteilung der Punkte
-
-In jedem Zyklus erstellen Sie in der ersten Woche Ihr Konzept und in der zweiten
-Woche die zugehörige Implementierung. Sie geben einmal Peer-Feedback für die Konzepte
-und einmal für die Implementierungen ab.
-
-Sie können sich in jedem Zyklus Aufgaben für 15 Punkte frei aussuchen.
-
-Dabei kann jede Aufgabe natürlich nur einmal bearbeitet und abgeben werden. Die
-"freien Aufgaben" können dagegen mehrfach bearbeitet werden, sofern Sie jedes Mal
-andere Inhalte wählen.
 
 Um in einem Zyklus die Punkte zu bekommen, ist nicht nur guter Code notwendig. Sie
 müssen auch an den "Vorarbeiten" ausreichend teilgenommen haben. Das bedeutet, dass
@@ -349,18 +328,18 @@ Sie jeden der sechs Schritte erfolgreich durchlaufen haben:
 
 -   Erste Woche: Konzeptphase
 
-    1.  Fristgerechte Einreichung der ausreichenden Konzeptskizze,
-    2.  Sinnvolles Peer-Feedback für die Konzepte,
-    3.  Vorstellung der Konzeptskizze im Praktikum,
+    1.  Fristgerechte Einreichung der ausreichenden Konzeptskizze (einzeln),
+    2.  Sinnvolles Peer-Feedback für die Konzepte (einzeln),
+    3.  Vorstellung der Konzeptskizze im Praktikum (Team),
 
 -   Zweite Woche: Implementierungsphase
 
-    4.  Fristgerechte Einreichung der Implementierung,
-    5.  Sinnvolles Peer-Feedback für die Implementierungen,
-    6.  Vorstellung der Implementierung im Praktikum.
+    4.  Fristgerechte Einreichung der Implementierung (einzeln),
+    5.  Sinnvolles Peer-Feedback für die Implementierungen (einzeln),
+    6.  Vorstellung der Implementierung im Praktikum (Team).
 
-**Pro Zyklus** können Sie maximal **15 Punkte für die Lösung** (den Code selbst) erhalten.
-Dazu kommen in den Zyklen 3 bis 5 noch bis zu **5 Punkte für Codequalität**.
+Pro Zyklus können Sie maximal 15 Punkte für die Lösung (den Code selbst) erhalten.
+Dazu kommen in den Zyklen 3 bis 5 noch bis zu 5 Punkte für Codequalität.
 
 Wie immer bestimmt der Umfang und die Qualität Ihrer Lösung, wie viele der ausgeschriebenen
 Punkte Sie für die bearbeiteten Aufgaben tatsächlich erhalten. Lösungen, die sich nicht

--- a/markdown/org/grading.md
+++ b/markdown/org/grading.md
@@ -13,8 +13,10 @@ hidden: true
 **Performanzprüfung, 7 ECTS**
 
 -   **Praktische Teilleistung**:
-    Regelmäßige Bearbeitung der Praktikumsaufgaben, fristgerechte Abgabe der Lösungen im ILIAS,
-    Erstellung von Peer-Feedback, Vorstellung der Lösungen im Praktikum => Punkte
+    Regelmäßige Bearbeitung der Praktikumsaufgaben,
+    fristgerechte Abgabe der Lösungen im ILIAS,
+    Erstellung von Peer-Feedback im ILIAS,
+    Vorstellung der Lösungen im Praktikum => Punkte
 
     Notenspiegel:
     -   90 Punkte gesamt erreichbar: Zyklus 1 und 2 je 15 Punkte, Zyklus 3 bis 5 je 15+5 Punkte

--- a/markdown/org/grading.md
+++ b/markdown/org/grading.md
@@ -47,48 +47,26 @@ im Prüfungsverfahren.
 
 Das Praktikum erfolgt in 2-Wochen-Zyklen:
 
-1.  Erste Woche: Konzeptphase
-    -   Auswahl der zu bearbeitenden Aufgaben
-    -   Erstellung und Abgabe einer Konzeptskizze (PDF)
-    -   Peer-Feedback zur Konzeptskizze
-    -   Vorstellung der Konzeptskizze im Praktikum
-2.  Zweite Woche: Implementierungsphase
-    -   Umsetzung des Konzepts/Implementierung der Lösung
-    -   Abgabe des Quellcodes (ZIP)
-    -   Peer-Feedback zum Quellcode
-    -   Vorstellung des Quellcodes im Praktikum
+1.  Erste Zyklus-Woche: Konzeptphase
+    -   Auswahl der zu bearbeitenden Aufgaben (=> Team)
+    -   Erstellung einer Konzeptskizze (PDF) (=> Team)
+    -   Abgabe der Konzeptskizze (PDF) im ILIAS (=> Jede(r) einzeln)
+    -   Peer-Feedback zur Konzeptskizze im ILIAS (=> Jede(r) einzeln)
+    -   Vorstellung der Konzeptskizze im Praktikum (=> Team)
+2.  Zweite Zyklus-Woche: Implementierungsphase
+    -   Umsetzung des Konzepts/Implementierung der Lösung (=> Team)
+    -   Abgabe des Quellcodes (ZIP) im ILIAS (=> Jede(r) einzeln)
+    -   Peer-Feedback zum Quellcode im ILIAS (=> Jede(r) einzeln)
+    -   Vorstellung des Quellcodes im Praktikum (=> Team)
 
 Sie können pro Zyklus Aufgaben im Umfang von 15 Punkten abgeben/vorstellen.
 
-### Abgabe der Lösungen
-
-Sofern nichts anderes bei den Aufgaben angegeben ist, sind die
-**Lösungen jeweils bis Mittwoch 15:00 Uhr im ILIAS** hochzuladen.
-
-### Peer-Feedback
-
-Sofern nicht anders angegeben, ist das **Peer-Feedback jeweils bis Donnerstag 15:00 Uhr**
-im ILIAS einzutragen.
-
-### Vorstellung der Lösung
-
-Die Lösungen werden von allen Teammitgliedern im Praktikum zur Erlangung der Punkte
-vorgestellt. Ohne aktive Teilnahme an der Vorstellung gibt es keine Punkte.
-
 ### Punktevergabe
 
-**Pro Zyklus** können Sie maximal **15 Punkte für die Lösung** (den Code selbst) erhalten.
-
-In den **Zyklen 3 bis 5** bekommen Sie **zusätzlich _bis_ zu 5 Punkte** für die Einhaltung
-einfacher Coding-Rules:
-
--   Einhaltung des PM-Coding-Styles: +2P
--   Durchgängige Dokumentation mit Javadoc: +2P
--   Durchgängiger Einsatz von Logging: +1P
-
-Für die Vergabe der Punkte müssen Sie Ihre Konzeptskizze eingereicht und vorgestellt haben,
-in beiden Zyklen-Hälften das Peer-Feedback erstellt haben und die Lösung (Quellcode) eingereicht
-und vorgestellt haben.
+Für die Vergabe der Punkte müssen Sie pro Zyklus jeweils fristgerecht
+Ihre Konzeptskizze eingereicht und im Praktikum vorgestellt haben,
+in beiden Zyklen-Hälften das Peer-Feedback erstellt haben und
+die Lösung (Quellcode) eingereicht und im Praktikum vorgestellt haben.
 
 ### Sonderabgabe letzte Vorlesungswoche
 
@@ -96,7 +74,4 @@ Zusatztermin für Studierende, die bis dahin unterhalb der Bestehensschwelle fü
 Teilleistung liegen oder die wegen Krankheit einen Termin nicht wahrnehmen konnten.
 
 Für diese Abgabe gibt es keine Konzeptphase und auch kein Peer-Feedback, die Lösung ist bis
-zum 30.06.23 um 09:00 Uhr im ILIAS hochzuladen und im nachfolgenden Praktikum vorzustellen.
-
-Sie können hier wie bei den anderen Zyklen Aufgaben bis zu 15 Punkten bearbeiten und zusätzlich
-noch bis zu 5 Punkte für die Codequalität erhalten.
+zur Deadline im ILIAS hochzuladen und im nachfolgenden Praktikum vorzustellen.


### PR DESCRIPTION
- Schedule: passe die Abgabezeiten an (neue Abgabe: Donnerstag, 8 Uhr)
- Schedule: ergänze Deadline für Feedback (Freitag, 8 Uhr)
- Landing Page: formuliere Abgabehinweis unter Schedule-Tabelle generisch
- Grading: reduziere Text (nur prüfungsrelevante Inhalte)
- Grading: entferne konkrete Zeiten
- Grading: formuliere generischer
- FAQ: entferne Redundanzen
- FAQ: entferne konkrete Zeiten

löst zum Teil #682