### PR TITLE
[ORG] Erstelle für jede Zyklus-Woche ein eigenes Blatt mit Arbeitsanweisungen

### DIFF
--- a/data/schedule.yaml
+++ b/data/schedule.yaml
@@ -25,10 +25,8 @@
         -   topic: "/modern-java/records"
         -   topic: "/pattern/strategy"
     assignment:
-        -   topic: "/assignments"
+        -   topic: "b01a"
             due: "Do, 20.04., 08 Uhr; Peer-Feedback: Fr, 21.04., 08 Uhr"
-    misc_assignment:
-        -   notes: ">> Zyklus 1: Abgabe und Vorstellung Konzept"
 
 -   week: "W04 (28. April)"
     lecture:
@@ -37,10 +35,8 @@
         -   topic: "/modern-java/lambdas"
         -   topic: "/modern-java/methodreferences"
     assignment:
-        -   topic: "/assignments"
+        -   topic: "b01b"
             due: "Do, 27.04., 08 Uhr; Peer-Feedback: Fr, 28.04., 08 Uhr"
-    misc_assignment:
-        -   notes: ">> Zyklus 1: Abgabe und Vorstellung Code"
 
 -   week: "W05 (05. Mai)"
     lecture:
@@ -49,10 +45,8 @@
         -   topic: "/coding/logging"
         -   topic: "/pattern/type-object"
     assignment:
-        -   topic: "/assignments"
+        -   topic: "b02a"
             due: "Do, 04.05., 08 Uhr; Peer-Feedback: Fr, 05.05., 08 Uhr"
-    misc_assignment:
-        -   notes: ">> Zyklus 2: Abgabe und Vorstellung Konzept"
 
 -   week: "W06 (12. Mai)"
     lecture:
@@ -64,10 +58,8 @@
     misc_lecture:
         -   notes: ">> Gastvortrag zu JUnit/Mocking in der Praxis von Daniel Rosowski (Smartsquare GmbH, Bielefeld)"
     assignment:
-        -   topic: "/assignments"
+        -   topic: "b02b"
             due: "Do, 11.05., 08 Uhr; Peer-Feedback: Fr, 12.05., 08 Uhr"
-    misc_assignment:
-        -   notes: ">> Zyklus 2: Abgabe und Vorstellung Code"
 
 -   week: "W07 (19. Mai)"
     lecture:
@@ -76,10 +68,8 @@
         -   topic: "/coding/refactoring"
         -   topic: "/building/ci"
     assignment:
-        -   topic: "/assignments"
+        -   topic: "b03a"
             due: "Do, 18.05., 08 Uhr; Peer-Feedback: Fr, 19.05., 08 Uhr"
-    misc_assignment:
-        -   notes: ">> Zyklus 3: Abgabe und Vorstellung Konzept"
 
 -   week: "W08 (26. Mai)"
     lecture:
@@ -89,10 +79,8 @@
         -   topic: "/generics/generics-polymorphism"
         -   topic: "/building/docker"
     assignment:
-        -   topic: "/assignments"
+        -   topic: "b03b"
             due: "Do, 25.05., 08 Uhr; Peer-Feedback: Fr, 26.05., 08 Uhr"
-    misc_assignment:
-        -   notes: ">> Zyklus 3: Abgabe und Vorstellung Code"
 
 -   week: "W09 (02. Juni)"
     lecture:
@@ -102,10 +90,8 @@
         -   topic: "/pattern/observer"
         -   topic: "/git/worktree"
     assignment:
-        -   topic: "/assignments"
+        -   topic: "b04a"
             due: "Do, 01.06., 08 Uhr; Peer-Feedback: Fr, 02.06., 08 Uhr"
-    misc_assignment:
-        -   notes: ">> Zyklus 4: Abgabe und Vorstellung Konzept"
 
 -   week: "W10 (09. Juni)"
     lecture:
@@ -114,10 +100,8 @@
         -   topic: "/java-jvm/exceptions"
         -   topic: "/pattern/singleton"
     assignment:
-        -   topic: "/assignments"
+        -   topic: "b04b"
             due: "Do, 08.06., 08 Uhr; Peer-Feedback: Fr, 09.06., 08 Uhr"
-    misc_assignment:
-        -   notes: ">> Zyklus 4: Abgabe und Vorstellung Code"
 
 -   week: "W11 (16. Juni)"
     lecture:
@@ -128,10 +112,8 @@
         -   topic: "/modern-java/sealed"
         -   topic: "/pattern/dependency"
     assignment:
-        -   topic: "/assignments"
+        -   topic: "b05a"
             due: "Do, 15.06., 08 Uhr; Peer-Feedback: Fr, 16.06., 08 Uhr"
-    misc_assignment:
-        -   notes: ">> Zyklus 5: Abgabe und Vorstellung Konzept"
 
 -   week: "W12 (23. Juni)"
     lecture:
@@ -141,10 +123,8 @@
         -   topic: "/pattern/factory-method"
         -   topic: "/pattern/template-method"
     assignment:
-        -   topic: "/assignments"
+        -   topic: "b05b"
             due: "Do, 22.06., 08 Uhr; Peer-Feedback: Fr, 23.06., 08 Uhr"
-    misc_assignment:
-        -   notes: ">> Zyklus 5: Abgabe und Vorstellung Code"
 
 -   week: "W13 (30. Juni)"
     lecture:
@@ -153,7 +133,5 @@
         -   topic: "/org/exams"
             notes: "Prüfungsvorbereitung (Zoom)"
     assignment:
-        -   topic: "/assignments"
+        -   topic: "b06"
             due: "Fr, 30.06., 09 Uhr"
-    misc_assignment:
-        -   notes: ">> Sondertermin (bei 'nicht bestanden')"

--- a/markdown/assignments/b01a.md
+++ b/markdown/assignments/b01a.md
@@ -1,0 +1,33 @@
+---
+archetype: assignment
+title: "Zyklus 1: Konzept"
+author: "Carsten Gips (FH Bielefeld)"
+weight: 1
+
+hidden: true
+---
+
+
+## Zyklus 1 (erste Woche): Konzeptphase
+
+Suchen Sie sich gemeinsam im Team die `[**Aufgaben**]({{< ref "/assignments/" >}})`{=markdown}
+aus, die Sie in diesem Zyklus bearbeiten wollen, und erstellen Sie dafür ein **Lösungskonzept**.[^1]
+
+Sie können in diesem Zyklus Aufgaben im Umfang von 15 Punkten abgeben/vorstellen.
+
+Die Konzeptskizze laden Sie bitte bis zur Deadline (s.o.) als PDF in die jeweilige ILIAS-Aufgabe
+hoch. **Wichtig**: Diese Abgabe muss aus technischen Gründen bitte **jedes Team-Mitglied einzeln**
+machen.[^2]
+
+Anschließend erfolgt die Peer-Feedback-Phase. ILIAS weist Ihnen mehrere Abgaben zu und Sie haben einen
+Tag Zeit, um Ihr Feedback im ILIAS abzugeben. Das Feedback muss **einzeln von jedem Team-Mitglied**
+bearbeitet werden.[^3]
+
+Im Praktikum am Freitag in dieser Zyklus-Woche stellen Sie im Team Ihr Konzept und das erhaltene
+Peer-Feedback vor. Dabei ist jedes Team-Mitglied anwesend und kann Auskunft geben.[^4]
+
+
+[^1]: vgl. `[Konzeptskizze]({{< ref "/org/faq#konzeptskizze" >}})`{=markdown} in der FAQ
+[^2]: vgl. `[Abgabe der Lösungen]({{< ref "/org/faq#abgabe-der-lösungen" >}})`{=markdown} in der FAQ
+[^3]: vgl. `[Peer-Feedback: How to Review]({{< ref "/org/faq#peer-feedback-how-to-review" >}})`{=markdown} in der FAQ
+[^4]: vgl. `[Vorstellung der Lösungen]({{< ref "/org/faq#vorstellung-der-lösungen" >}})`{=markdown} in der FAQ

--- a/markdown/assignments/b01b.md
+++ b/markdown/assignments/b01b.md
@@ -1,0 +1,34 @@
+---
+archetype: assignment
+title: "Zyklus 1: Implementierung"
+author: "Carsten Gips (FH Bielefeld)"
+points: 15
+weight: 2
+
+hidden: true
+---
+
+
+## Zyklus 1 (zweite Woche): Implementierungsphase
+
+Setzen Sie gemeinsam im Team Ihr Konzept aus der
+`[ersten Zyklushälfte]({{< ref "/assignments/b01a" >}})`{=markdown}
+in eine **Implementierung** um.
+
+Den Quellcode und die sonstigen bei der Bearbeitung erstellten Artefakte (Texte,
+Texturen, ..., aber bitte keine `.class`-Dateien) laden Sie bitte bis zur Deadline
+(s.o.) als ZIP in die jeweilige ILIAS-Aufgabe hoch. **Wichtig**: Diese Abgabe muss
+aus technischen Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
+
+Anschließend erfolgt eine erneute Peer-Feedback-Phase. ILIAS weist Ihnen wieder
+mehrere Abgaben zu und Sie haben einen Tag Zeit, um Ihr Feedback im ILIAS abzugeben.
+Das Feedback muss wieder **einzeln von jedem Team-Mitglied** bearbeitet werden.[^3]
+
+Im Praktikum am Freitag in dieser Zyklus-Woche stellen Sie im Team Ihre Implementierung
+und das erhaltene Peer-Feedback vor. Dabei ist jedes Team-Mitglied anwesend und kann
+Auskunft geben.[^4]
+
+
+[^2]: vgl. `[Abgabe der Lösungen]({{< ref "/org/faq#abgabe-der-lösungen" >}})`{=markdown} in der FAQ
+[^3]: vgl. `[Peer-Feedback: How to Review]({{< ref "/org/faq#peer-feedback-how-to-review" >}})`{=markdown} in der FAQ
+[^4]: vgl. `[Vorstellung der Lösungen]({{< ref "/org/faq#vorstellung-der-lösungen" >}})`{=markdown} in der FAQ

--- a/markdown/assignments/b02a.md
+++ b/markdown/assignments/b02a.md
@@ -1,0 +1,33 @@
+---
+archetype: assignment
+title: "Zyklus 2: Konzept"
+author: "Carsten Gips (FH Bielefeld)"
+weight: 3
+
+hidden: true
+---
+
+
+## Zyklus 2 (erste Woche): Konzeptphase
+
+Suchen Sie sich gemeinsam im Team die `[**Aufgaben**]({{< ref "/assignments/" >}})`{=markdown}
+aus, die Sie in diesem Zyklus bearbeiten wollen, und erstellen Sie dafür ein **Lösungskonzept**.[^1]
+
+Sie können in diesem Zyklus Aufgaben im Umfang von 15 Punkten abgeben/vorstellen.
+
+Die Konzeptskizze laden Sie bitte bis zur Deadline (s.o.) als PDF in die jeweilige ILIAS-Aufgabe
+hoch. **Wichtig**: Diese Abgabe muss aus technischen Gründen bitte **jedes Team-Mitglied einzeln**
+machen.[^2]
+
+Anschließend erfolgt die Peer-Feedback-Phase. ILIAS weist Ihnen mehrere Abgaben zu und Sie haben einen
+Tag Zeit, um Ihr Feedback im ILIAS abzugeben. Das Feedback muss **einzeln von jedem Team-Mitglied**
+bearbeitet werden.[^3]
+
+Im Praktikum am Freitag in dieser Zyklus-Woche stellen Sie im Team Ihr Konzept und das erhaltene
+Peer-Feedback vor. Dabei ist jedes Team-Mitglied anwesend und kann Auskunft geben.[^4]
+
+
+[^1]: vgl. `[Konzeptskizze]({{< ref "/org/faq#konzeptskizze" >}})`{=markdown} in der FAQ
+[^2]: vgl. `[Abgabe der Lösungen]({{< ref "/org/faq#abgabe-der-lösungen" >}})`{=markdown} in der FAQ
+[^3]: vgl. `[Peer-Feedback: How to Review]({{< ref "/org/faq#peer-feedback-how-to-review" >}})`{=markdown} in der FAQ
+[^4]: vgl. `[Vorstellung der Lösungen]({{< ref "/org/faq#vorstellung-der-lösungen" >}})`{=markdown} in der FAQ

--- a/markdown/assignments/b02b.md
+++ b/markdown/assignments/b02b.md
@@ -1,0 +1,34 @@
+---
+archetype: assignment
+title: "Zyklus 2: Implementierung"
+author: "Carsten Gips (FH Bielefeld)"
+points: 15
+weight: 4
+
+hidden: true
+---
+
+
+## Zyklus 2 (zweite Woche): Implementierungsphase
+
+Setzen Sie gemeinsam im Team Ihr Konzept aus der
+`[ersten Zyklushälfte]({{< ref "/assignments/b02a" >}})`{=markdown}
+in eine **Implementierung** um.
+
+Den Quellcode und die sonstigen bei der Bearbeitung erstellten Artefakte (Texte,
+Texturen, ..., aber bitte keine `.class`-Dateien) laden Sie bitte bis zur Deadline
+(s.o.) als ZIP in die jeweilige ILIAS-Aufgabe hoch. **Wichtig**: Diese Abgabe muss
+aus technischen Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
+
+Anschließend erfolgt eine erneute Peer-Feedback-Phase. ILIAS weist Ihnen wieder
+mehrere Abgaben zu und Sie haben einen Tag Zeit, um Ihr Feedback im ILIAS abzugeben.
+Das Feedback muss wieder **einzeln von jedem Team-Mitglied** bearbeitet werden.[^3]
+
+Im Praktikum am Freitag in dieser Zyklus-Woche stellen Sie im Team Ihre Implementierung
+und das erhaltene Peer-Feedback vor. Dabei ist jedes Team-Mitglied anwesend und kann
+Auskunft geben.[^4]
+
+
+[^2]: vgl. `[Abgabe der Lösungen]({{< ref "/org/faq#abgabe-der-lösungen" >}})`{=markdown} in der FAQ
+[^3]: vgl. `[Peer-Feedback: How to Review]({{< ref "/org/faq#peer-feedback-how-to-review" >}})`{=markdown} in der FAQ
+[^4]: vgl. `[Vorstellung der Lösungen]({{< ref "/org/faq#vorstellung-der-lösungen" >}})`{=markdown} in der FAQ

--- a/markdown/assignments/b03a.md
+++ b/markdown/assignments/b03a.md
@@ -1,0 +1,33 @@
+---
+archetype: assignment
+title: "Zyklus 3: Konzept"
+author: "Carsten Gips (FH Bielefeld)"
+weight: 5
+
+hidden: true
+---
+
+
+## Zyklus 3 (erste Woche): Konzeptphase
+
+Suchen Sie sich gemeinsam im Team die `[**Aufgaben**]({{< ref "/assignments/" >}})`{=markdown}
+aus, die Sie in diesem Zyklus bearbeiten wollen, und erstellen Sie dafür ein **Lösungskonzept**.[^1]
+
+Sie können in diesem Zyklus Aufgaben im Umfang von 15 Punkten abgeben/vorstellen.
+
+Die Konzeptskizze laden Sie bitte bis zur Deadline (s.o.) als PDF in die jeweilige ILIAS-Aufgabe
+hoch. **Wichtig**: Diese Abgabe muss aus technischen Gründen bitte **jedes Team-Mitglied einzeln**
+machen.[^2]
+
+Anschließend erfolgt die Peer-Feedback-Phase. ILIAS weist Ihnen mehrere Abgaben zu und Sie haben einen
+Tag Zeit, um Ihr Feedback im ILIAS abzugeben. Das Feedback muss **einzeln von jedem Team-Mitglied**
+bearbeitet werden.[^3]
+
+Im Praktikum am Freitag in dieser Zyklus-Woche stellen Sie im Team Ihr Konzept und das erhaltene
+Peer-Feedback vor. Dabei ist jedes Team-Mitglied anwesend und kann Auskunft geben.[^4]
+
+
+[^1]: vgl. `[Konzeptskizze]({{< ref "/org/faq#konzeptskizze" >}})`{=markdown} in der FAQ
+[^2]: vgl. `[Abgabe der Lösungen]({{< ref "/org/faq#abgabe-der-lösungen" >}})`{=markdown} in der FAQ
+[^3]: vgl. `[Peer-Feedback: How to Review]({{< ref "/org/faq#peer-feedback-how-to-review" >}})`{=markdown} in der FAQ
+[^4]: vgl. `[Vorstellung der Lösungen]({{< ref "/org/faq#vorstellung-der-lösungen" >}})`{=markdown} in der FAQ

--- a/markdown/assignments/b03b.md
+++ b/markdown/assignments/b03b.md
@@ -1,0 +1,41 @@
+---
+archetype: assignment
+title: "Zyklus 3: Implementierung"
+author: "Carsten Gips (FH Bielefeld)"
+points: 20
+weight: 6
+
+hidden: true
+---
+
+
+## Zyklus 3 (zweite Woche): Implementierungsphase
+
+Setzen Sie gemeinsam im Team Ihr Konzept aus der
+`[ersten Zyklushälfte]({{< ref "/assignments/b03a" >}})`{=markdown}
+in eine **Implementierung** um.
+
+Sie können in diesem Zyklus Aufgaben im Umfang von 15 Punkten abgeben/vorstellen.
+Zusätzlich bekommen Sie _bis_ zu 5 Punkte für die Einhaltung einfacher Coding-Rules:
+
+-   Einhaltung des PM-Coding-Styles: +2P
+-   Durchgängige Dokumentation mit Javadoc: +2P
+-   Durchgängiger Einsatz von Logging: +1P
+
+Den Quellcode und die sonstigen bei der Bearbeitung erstellten Artefakte (Texte,
+Texturen, ..., aber bitte keine `.class`-Dateien) laden Sie bitte bis zur Deadline
+(s.o.) als ZIP in die jeweilige ILIAS-Aufgabe hoch. **Wichtig**: Diese Abgabe muss
+aus technischen Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
+
+Anschließend erfolgt eine erneute Peer-Feedback-Phase. ILIAS weist Ihnen wieder
+mehrere Abgaben zu und Sie haben einen Tag Zeit, um Ihr Feedback im ILIAS abzugeben.
+Das Feedback muss wieder **einzeln von jedem Team-Mitglied** bearbeitet werden.[^3]
+
+Im Praktikum am Freitag in dieser Zyklus-Woche stellen Sie im Team Ihre Implementierung
+und das erhaltene Peer-Feedback vor. Dabei ist jedes Team-Mitglied anwesend und kann
+Auskunft geben.[^4]
+
+
+[^2]: vgl. `[Abgabe der Lösungen]({{< ref "/org/faq#abgabe-der-lösungen" >}})`{=markdown} in der FAQ
+[^3]: vgl. `[Peer-Feedback: How to Review]({{< ref "/org/faq#peer-feedback-how-to-review" >}})`{=markdown} in der FAQ
+[^4]: vgl. `[Vorstellung der Lösungen]({{< ref "/org/faq#vorstellung-der-lösungen" >}})`{=markdown} in der FAQ

--- a/markdown/assignments/b04a.md
+++ b/markdown/assignments/b04a.md
@@ -1,0 +1,33 @@
+---
+archetype: assignment
+title: "Zyklus 4: Konzept"
+author: "Carsten Gips (FH Bielefeld)"
+weight: 6
+
+hidden: true
+---
+
+
+## Zyklus 4 (erste Woche): Konzeptphase
+
+Suchen Sie sich gemeinsam im Team die `[**Aufgaben**]({{< ref "/assignments/" >}})`{=markdown}
+aus, die Sie in diesem Zyklus bearbeiten wollen, und erstellen Sie dafür ein **Lösungskonzept**.[^1]
+
+Sie können in diesem Zyklus Aufgaben im Umfang von 15 Punkten abgeben/vorstellen.
+
+Die Konzeptskizze laden Sie bitte bis zur Deadline (s.o.) als PDF in die jeweilige ILIAS-Aufgabe
+hoch. **Wichtig**: Diese Abgabe muss aus technischen Gründen bitte **jedes Team-Mitglied einzeln**
+machen.[^2]
+
+Anschließend erfolgt die Peer-Feedback-Phase. ILIAS weist Ihnen mehrere Abgaben zu und Sie haben einen
+Tag Zeit, um Ihr Feedback im ILIAS abzugeben. Das Feedback muss **einzeln von jedem Team-Mitglied**
+bearbeitet werden.[^3]
+
+Im Praktikum am Freitag in dieser Zyklus-Woche stellen Sie im Team Ihr Konzept und das erhaltene
+Peer-Feedback vor. Dabei ist jedes Team-Mitglied anwesend und kann Auskunft geben.[^4]
+
+
+[^1]: vgl. `[Konzeptskizze]({{< ref "/org/faq#konzeptskizze" >}})`{=markdown} in der FAQ
+[^2]: vgl. `[Abgabe der Lösungen]({{< ref "/org/faq#abgabe-der-lösungen" >}})`{=markdown} in der FAQ
+[^3]: vgl. `[Peer-Feedback: How to Review]({{< ref "/org/faq#peer-feedback-how-to-review" >}})`{=markdown} in der FAQ
+[^4]: vgl. `[Vorstellung der Lösungen]({{< ref "/org/faq#vorstellung-der-lösungen" >}})`{=markdown} in der FAQ

--- a/markdown/assignments/b04b.md
+++ b/markdown/assignments/b04b.md
@@ -1,0 +1,41 @@
+---
+archetype: assignment
+title: "Zyklus 4: Implementierung"
+author: "Carsten Gips (FH Bielefeld)"
+points: 20
+weight: 8
+
+hidden: true
+---
+
+
+## Zyklus 4 (zweite Woche): Implementierungsphase
+
+Setzen Sie gemeinsam im Team Ihr Konzept aus der
+`[ersten Zyklushälfte]({{< ref "/assignments/b04a" >}})`{=markdown}
+in eine **Implementierung** um.
+
+Sie können in diesem Zyklus Aufgaben im Umfang von 15 Punkten abgeben/vorstellen.
+Zusätzlich bekommen Sie _bis_ zu 5 Punkte für die Einhaltung einfacher Coding-Rules:
+
+-   Einhaltung des PM-Coding-Styles: +2P
+-   Durchgängige Dokumentation mit Javadoc: +2P
+-   Durchgängiger Einsatz von Logging: +1P
+
+Den Quellcode und die sonstigen bei der Bearbeitung erstellten Artefakte (Texte,
+Texturen, ..., aber bitte keine `.class`-Dateien) laden Sie bitte bis zur Deadline
+(s.o.) als ZIP in die jeweilige ILIAS-Aufgabe hoch. **Wichtig**: Diese Abgabe muss
+aus technischen Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
+
+Anschließend erfolgt eine erneute Peer-Feedback-Phase. ILIAS weist Ihnen wieder
+mehrere Abgaben zu und Sie haben einen Tag Zeit, um Ihr Feedback im ILIAS abzugeben.
+Das Feedback muss wieder **einzeln von jedem Team-Mitglied** bearbeitet werden.[^3]
+
+Im Praktikum am Freitag in dieser Zyklus-Woche stellen Sie im Team Ihre Implementierung
+und das erhaltene Peer-Feedback vor. Dabei ist jedes Team-Mitglied anwesend und kann
+Auskunft geben.[^4]
+
+
+[^2]: vgl. `[Abgabe der Lösungen]({{< ref "/org/faq#abgabe-der-lösungen" >}})`{=markdown} in der FAQ
+[^3]: vgl. `[Peer-Feedback: How to Review]({{< ref "/org/faq#peer-feedback-how-to-review" >}})`{=markdown} in der FAQ
+[^4]: vgl. `[Vorstellung der Lösungen]({{< ref "/org/faq#vorstellung-der-lösungen" >}})`{=markdown} in der FAQ

--- a/markdown/assignments/b05a.md
+++ b/markdown/assignments/b05a.md
@@ -1,0 +1,33 @@
+---
+archetype: assignment
+title: "Zyklus 5: Konzept"
+author: "Carsten Gips (FH Bielefeld)"
+weight: 9
+
+hidden: true
+---
+
+
+## Zyklus 5 (erste Woche): Konzeptphase
+
+Suchen Sie sich gemeinsam im Team die `[**Aufgaben**]({{< ref "/assignments/" >}})`{=markdown}
+aus, die Sie in diesem Zyklus bearbeiten wollen, und erstellen Sie dafür ein **Lösungskonzept**.[^1]
+
+Sie können in diesem Zyklus Aufgaben im Umfang von 15 Punkten abgeben/vorstellen.
+
+Die Konzeptskizze laden Sie bitte bis zur Deadline (s.o.) als PDF in die jeweilige ILIAS-Aufgabe
+hoch. **Wichtig**: Diese Abgabe muss aus technischen Gründen bitte **jedes Team-Mitglied einzeln**
+machen.[^2]
+
+Anschließend erfolgt die Peer-Feedback-Phase. ILIAS weist Ihnen mehrere Abgaben zu und Sie haben einen
+Tag Zeit, um Ihr Feedback im ILIAS abzugeben. Das Feedback muss **einzeln von jedem Team-Mitglied**
+bearbeitet werden.[^3]
+
+Im Praktikum am Freitag in dieser Zyklus-Woche stellen Sie im Team Ihr Konzept und das erhaltene
+Peer-Feedback vor. Dabei ist jedes Team-Mitglied anwesend und kann Auskunft geben.[^4]
+
+
+[^1]: vgl. `[Konzeptskizze]({{< ref "/org/faq#konzeptskizze" >}})`{=markdown} in der FAQ
+[^2]: vgl. `[Abgabe der Lösungen]({{< ref "/org/faq#abgabe-der-lösungen" >}})`{=markdown} in der FAQ
+[^3]: vgl. `[Peer-Feedback: How to Review]({{< ref "/org/faq#peer-feedback-how-to-review" >}})`{=markdown} in der FAQ
+[^4]: vgl. `[Vorstellung der Lösungen]({{< ref "/org/faq#vorstellung-der-lösungen" >}})`{=markdown} in der FAQ

--- a/markdown/assignments/b05b.md
+++ b/markdown/assignments/b05b.md
@@ -1,0 +1,41 @@
+---
+archetype: assignment
+title: "Zyklus 5: Implementierung"
+author: "Carsten Gips (FH Bielefeld)"
+points: 20
+weight: 10
+
+hidden: true
+---
+
+
+## Zyklus 5 (zweite Woche): Implementierungsphase
+
+Setzen Sie gemeinsam im Team Ihr Konzept aus der
+`[ersten Zyklushälfte]({{< ref "/assignments/b05a" >}})`{=markdown}
+in eine **Implementierung** um.
+
+Sie können in diesem Zyklus Aufgaben im Umfang von 15 Punkten abgeben/vorstellen.
+Zusätzlich bekommen Sie _bis_ zu 5 Punkte für die Einhaltung einfacher Coding-Rules:
+
+-   Einhaltung des PM-Coding-Styles: +2P
+-   Durchgängige Dokumentation mit Javadoc: +2P
+-   Durchgängiger Einsatz von Logging: +1P
+
+Den Quellcode und die sonstigen bei der Bearbeitung erstellten Artefakte (Texte,
+Texturen, ..., aber bitte keine `.class`-Dateien) laden Sie bitte bis zur Deadline
+(s.o.) als ZIP in die jeweilige ILIAS-Aufgabe hoch. **Wichtig**: Diese Abgabe muss
+aus technischen Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
+
+Anschließend erfolgt eine erneute Peer-Feedback-Phase. ILIAS weist Ihnen wieder
+mehrere Abgaben zu und Sie haben einen Tag Zeit, um Ihr Feedback im ILIAS abzugeben.
+Das Feedback muss wieder **einzeln von jedem Team-Mitglied** bearbeitet werden.[^3]
+
+Im Praktikum am Freitag in dieser Zyklus-Woche stellen Sie im Team Ihre Implementierung
+und das erhaltene Peer-Feedback vor. Dabei ist jedes Team-Mitglied anwesend und kann
+Auskunft geben.[^4]
+
+
+[^2]: vgl. `[Abgabe der Lösungen]({{< ref "/org/faq#abgabe-der-lösungen" >}})`{=markdown} in der FAQ
+[^3]: vgl. `[Peer-Feedback: How to Review]({{< ref "/org/faq#peer-feedback-how-to-review" >}})`{=markdown} in der FAQ
+[^4]: vgl. `[Vorstellung der Lösungen]({{< ref "/org/faq#vorstellung-der-lösungen" >}})`{=markdown} in der FAQ

--- a/markdown/assignments/b06.md
+++ b/markdown/assignments/b06.md
@@ -1,0 +1,40 @@
+---
+archetype: assignment
+title: "Sonderabgabe"
+author: "Carsten Gips (FH Bielefeld)"
+points: 20
+weight: 11
+
+hidden: true
+---
+
+
+## Sondertermin (bei sonst 'nicht bestanden' oder Krankheit)
+
+Dies ist ein Zusatzblatt für Studierende, die bis dahin unterhalb der Bestehensschwelle
+für die praktische Teilleistung liegen oder die wegen Krankheit einen Termin nicht
+wahrnehmen konnten.
+
+Für diese Abgabe gibt es keine Konzeptphase und auch kein Peer-Feedback, die Lösung ist
+bis zur Deadline (s.o.) im ILIAS hochzuladen und im nachfolgenden Praktikum vorzustellen.
+
+Suchen Sie sich die `[**Aufgaben**]({{< ref "/assignments/" >}})`{=markdown} aus, die Sie
+für diese Abgabe bearbeiten wollen, und **implementieren** dafür Sie Ihre **Lösung**.
+
+Sie können für diese Abgabe Aufgaben im Umfang von 15 Punkten abgeben/vorstellen.
+Zusätzlich bekommen Sie _bis_ zu 5 Punkte für die Einhaltung einfacher Coding-Rules:
+
+-   Einhaltung des PM-Coding-Styles: +2P
+-   Durchgängige Dokumentation mit Javadoc: +2P
+-   Durchgängiger Einsatz von Logging: +1P
+
+Den Quellcode und die sonstigen bei der Bearbeitung erstellten Artefakte (Texte,
+Texturen, ..., aber bitte keine `.class`-Dateien) laden Sie bitte bis zur Deadline
+(s.o.) als ZIP in die jeweilige ILIAS-Aufgabe hoch. **Wichtig**: Diese Abgabe muss
+aus technischen Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
+
+Im Praktikum am Freitag in dieser Zyklus-Woche stellen Sie Ihre Implementierung vor.[^4]
+
+
+[^2]: vgl. `[Abgabe der Lösungen]({{< ref "/org/faq#abgabe-der-lösungen" >}})`{=markdown} in der FAQ
+[^4]: vgl. `[Vorstellung der Lösungen]({{< ref "/org/faq#vorstellung-der-lösungen" >}})`{=markdown} in der FAQ


### PR DESCRIPTION
Die Bearbeitungszeiten wurden mit #683 bereits verlängert: Inhaltliche Bearbeitung bis Do, 8 Uhr und Feedback bis Fr, 8 Uhr und danach Vorstellung im Praktikum.

Dieser PR fügt nun noch für jede Zyklus-Woche ein eigenes "Übungsblatt" ein, welches konkrete Arbeitsanweisungen und die Deadlines für die Abgabe enthält. 

Damit dupliziert sich der Text (deutlich!). Andererseits können diese konkreten Blätter im Schedule und im ILIAS ("aktuelle Woche", Übungsobjekt) verlinkt werden und erzeugen so deutlich mehr (zeitliche) Übersicht für die Studierenden. Zusätzlich wandern Hinweise wie "hier nun auch +5P bei Clean Code" direkt mit auf die Blätter/Arbeitsanweisungen, d.h. die Studis sehen das direkt in der Aufgabe und müssen es nicht im Hinterkopf behalten.

fixes #682 