### PR TITLE
[VL] remove all 'assignments:' in YAML

### DIFF
--- a/markdown/building/gradle.md
+++ b/markdown/building/gradle.md
@@ -30,8 +30,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106220&client_id=FH-Bielefeld"
     name: "Quiz Gradle (ILIAS)"
-assignments:
-  - topic: sheet04
 youtube:
   - link: "https://youtu.be/aVtDkFpwd_E"
     name: "VL Build-Systeme: Gradle"

--- a/markdown/coding/codingrules.md
+++ b/markdown/coding/codingrules.md
@@ -57,8 +57,6 @@ outcomes:
   - k3: "Nutzung des Tools Spotless (Formatierung des Codes)"
   - k3: "Nutzung des Tools Checkstyle (Coding Conventions und Metriken)"
   - k3: "Nutzung des Tools SpotBugs (Vermeiden von Anti-Pattern)"
-assignments:
-  - topic: sheet05
 youtube:
   - link: "https://youtu.be/nLAEak6Fwfk"
     name: "VL Coding Conventions"

--- a/markdown/coding/debugging.md
+++ b/markdown/coding/debugging.md
@@ -21,8 +21,6 @@ outcomes:
 quizzes:
   - link: "XYZ"
     name: "Quiz XXX (ILIAS)"
-assignments:
-  - topic: sheet01
 youtube:
   - link: ""
     name: "VL "

--- a/markdown/coding/logging.md
+++ b/markdown/coding/logging.md
@@ -37,8 +37,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106228&client_id=FH-Bielefeld"
     name: "Quiz Logging (ILIAS)"
-assignments:
-  - topic: sheet02
 youtube:
   - link: "`https://youtu.be/_jYWJzr1rkA`{=markdown}"
     name: "VL Logging"

--- a/markdown/coding/refactoring.md
+++ b/markdown/coding/refactoring.md
@@ -30,8 +30,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106231&client_id=FH-Bielefeld"
     name: "Quiz Refactoring (ILIAS)"
-assignments:
-  - topic: sheet05
 youtube:
   - link: "https://youtu.be/n0RaQ_Qve0Y"
     name: "VL Refactoring"

--- a/markdown/coding/smells.md
+++ b/markdown/coding/smells.md
@@ -28,8 +28,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106230&client_id=FH-Bielefeld"
     name: "Quiz Code Smells (ILIAS)"
-assignments:
-  - topic: sheet05
 youtube:
   - link: "https://youtu.be/ALDuLxm71tg"
     name: "VL Code Smells"

--- a/markdown/database/jdbc.md
+++ b/markdown/database/jdbc.md
@@ -16,8 +16,6 @@ outcomes:
 quizzes:
   - link: "XYZ"
     name: "Quiz XXX (ILIAS)"
-assignments:
-  - topic: sheet01
 youtube:
   - link: ""
     name: "VL "

--- a/markdown/generics/bounds-wildcards.md
+++ b/markdown/generics/bounds-wildcards.md
@@ -30,8 +30,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106236&client_id=FH-Bielefeld"
     name: "Quiz Generics: Bounds & Wildcards (ILIAS)"
-assignments:
-  - topic: sheet03
 youtube:
   - link: "https://youtu.be/OV2vEn2EkWo"
     name: "VL Generics: Bounds & Wildcards"

--- a/markdown/generics/classes-methods.md
+++ b/markdown/generics/classes-methods.md
@@ -27,8 +27,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106235&client_id=FH-Bielefeld"
     name: "Quiz Generics: Classes & Methods (ILIAS)"
-assignments:
-  - topic: sheet03
 youtube:
   - link: "https://youtu.be/k6MFPW-shh8"
     name: "VL Generische Klassen & Methoden"

--- a/markdown/generics/generics-polymorphism.md
+++ b/markdown/generics/generics-polymorphism.md
@@ -26,8 +26,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106238&client_id=FH-Bielefeld"
     name: "Quiz Generics und Polymorphie (ILIAS)"
-assignments:
-  - topic: sheet03
 youtube:
   - link: "https://youtu.be/RiTA43wTixQ"
     name: "VL Generics und Polymorphie"

--- a/markdown/generics/type-erasure.md
+++ b/markdown/generics/type-erasure.md
@@ -24,8 +24,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106237&client_id=FH-Bielefeld"
     name: "Quiz Generics: Type Erasure (ILIAS)"
-assignments:
-  - topic: sheet03
 youtube:
   - link: "https://youtu.be/vo0WKkPBMAM"
     name: "VL Generics: Type Erasure"

--- a/markdown/git/basics.md
+++ b/markdown/git/basics.md
@@ -35,8 +35,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106241&client_id=FH-Bielefeld"
     name: "Quiz Git Basics (ILIAS)"
-assignments:
-  - topic: sheet01
 youtube:
   - link: "https://youtu.be/GxJI8nmZVE8"
     name: "VL Git Basics"

--- a/markdown/git/branches.md
+++ b/markdown/git/branches.md
@@ -37,8 +37,6 @@ quizzes:
     name: "Tutorial: Welcome to Learn Git Branching"
   - link: "https://marklodato.github.io/visual-git-guide/index-en.html"
     name: "Tutorial: A Visual Git Reference"
-assignments:
-  - topic: sheet01
 youtube:
   - link: "https://youtu.be/WXPJOsgeR10"
     name: "VL Git Branches"

--- a/markdown/git/branching-strategies.md
+++ b/markdown/git/branching-strategies.md
@@ -36,8 +36,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106243&client_id=FH-Bielefeld"
     name: "Quiz Git Branching-Strategien (ILIAS)"
-assignments:
-  - topic: sheet01
 youtube:
   - link: "https://youtu.be/v1WHIPdoA0k"
     name: "VL Git Branching-Strategien"

--- a/markdown/git/intro.md
+++ b/markdown/git/intro.md
@@ -35,8 +35,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106239&client_id=FH-Bielefeld"
     name: "Quiz Git Intro (ILIAS)"
-assignments:
-  - topic: sheet01
 youtube:
   - link: "https://youtu.be/Ac3-pZhVf_c"
     name: "VL Git Intro"

--- a/markdown/git/remotes.md
+++ b/markdown/git/remotes.md
@@ -43,8 +43,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106245&client_id=FH-Bielefeld"
     name: "Quiz Git Remotes (ILIAS)"
-assignments:
-  - topic: sheet01
 youtube:
   - link: "`https://youtu.be/_uhEseblDYU`{=markdown}"
     name: "VL Git Remotes"

--- a/markdown/git/workflows.md
+++ b/markdown/git/workflows.md
@@ -37,8 +37,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106246&client_id=FH-Bielefeld"
     name: "Quiz Git Workflows (ILIAS)"
-assignments:
-  - topic: sheet01
 youtube:
   - link: "https://youtu.be/3xqmNGN39wE"
     name: "VL Git Workflows"

--- a/markdown/java-jvm/annotations.md
+++ b/markdown/java-jvm/annotations.md
@@ -33,8 +33,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106512&client_id=FH-Bielefeld"
     name: "Quiz Annotationen (ILIAS)"
-assignments:
-  - topic: sheet07
 youtube:
   - link: "https://youtu.be/7u4_I4W_1JY"
     name: "VL Annotationen"

--- a/markdown/java-jvm/enums.md
+++ b/markdown/java-jvm/enums.md
@@ -26,8 +26,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106515&client_id=FH-Bielefeld"
     name: "Quiz Enumerations (ILIAS)"
-assignments:
-  - topic: sheet06
 youtube:
   - link: "https://youtu.be/qoeT9jVuQZc"
     name: "VL Enumerations"

--- a/markdown/java-jvm/reflection.md
+++ b/markdown/java-jvm/reflection.md
@@ -36,8 +36,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106517&client_id=FH-Bielefeld"
     name: "Quiz Reflection (ILIAS)"
-assignments:
-  - topic: sheet07
 youtube:
   - link: "https://youtu.be/7wTKl8-KYd0"
     name: "VL Reflection"

--- a/markdown/java-jvm/regexp.md
+++ b/markdown/java-jvm/regexp.md
@@ -38,8 +38,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106518&client_id=FH-Bielefeld"
     name: "Quiz RegExp (ILIAS)"
-assignments:
-  - topic: sheet08
 youtube:
   - link: "https://youtu.be/K9R1Bwa73uI"
     name: "VL RegExp"

--- a/markdown/modern-java/defaultmethods.md
+++ b/markdown/modern-java/defaultmethods.md
@@ -38,8 +38,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106522&client_id=FH-Bielefeld"
     name: "Quiz Default-Methoden (ILIAS)"
-assignments:
-  - topic: sheet08
 youtube:
   - link: "https://youtu.be/qQ8BPkL9X5o"
     name: "VL Default-Methoden"

--- a/markdown/modern-java/lambdas.md
+++ b/markdown/modern-java/lambdas.md
@@ -46,8 +46,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106523&client_id=FH-Bielefeld"
     name: "Quiz Lambda-Ausdrücke und funktionale Interfaces (ILIAS)"
-assignments:
-  - topic: sheet08
 youtube:
   - link: "https://youtu.be/Wd8KG7xtp4c"
     name: "VL Lambda-Ausdrücke und funktionale Interfaces"

--- a/markdown/modern-java/methodreferences.md
+++ b/markdown/modern-java/methodreferences.md
@@ -31,8 +31,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106524&client_id=FH-Bielefeld"
     name: "Quiz Methoden-Referenzen (ILIAS)"
-assignments:
-  - topic: sheet08
 youtube:
   - link: "https://youtu.be/z0mfvvrsRzc"
     name: "VL Methoden-Referenzen"

--- a/markdown/modern-java/optional.md
+++ b/markdown/modern-java/optional.md
@@ -43,8 +43,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106526&client_id=FH-Bielefeld"
     name: "Quiz Optional (ILIAS)"
-assignments:
-  - topic: sheet09
 youtube:
   - link: "https://youtu.be/JDG_hUSBfSA"
     name: "VL Optional"

--- a/markdown/modern-java/records.md
+++ b/markdown/modern-java/records.md
@@ -44,8 +44,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106527&client_id=FH-Bielefeld"
     name: "Quiz Record-Klassen (ILIAS)"
-assignments:
-  - topic: sheet09
 youtube:
   - link: "https://youtu.be/5RMhdCsZL6Y"
     name: "VL Record-Klassen"

--- a/markdown/modern-java/stream-api.md
+++ b/markdown/modern-java/stream-api.md
@@ -49,8 +49,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106528&client_id=FH-Bielefeld"
     name: "Quiz Stream-API (ILIAS)"
-assignments:
-  - topic: sheet09
 youtube:
   - link: "https://youtu.be/zZMyk0u5hJk"
     name: "VL Stream-API"

--- a/markdown/pattern/command.md
+++ b/markdown/pattern/command.md
@@ -31,8 +31,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106532&client_id=FH-Bielefeld"
     name: "Quiz Command-Pattern (ILIAS)"
-assignments:
-  - topic: sheet09
 youtube:
   - link: "https://youtu.be/F7RJ7YCVMS4"
     name: "VL Command-Pattern"

--- a/markdown/pattern/factory-method.md
+++ b/markdown/pattern/factory-method.md
@@ -25,8 +25,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106533&client_id=FH-Bielefeld"
     name: "Quiz Factory-Method-Pattern (ILIAS)"
-assignments:
-  - topic: sheet02
 youtube:
   - link: "https://youtu.be/mJWe-2BS2W0"
     name: "VL Factory-Method-Pattern"

--- a/markdown/pattern/observer.md
+++ b/markdown/pattern/observer.md
@@ -26,8 +26,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106535&client_id=FH-Bielefeld"
     name: "Quiz Observer-Pattern (ILIAS)"
-assignments:
-  - topic: sheet06
 youtube:
   - link: "https://youtu.be/833lHcoxeog"
     name: "VL Observer-Pattern"

--- a/markdown/pattern/singleton.md
+++ b/markdown/pattern/singleton.md
@@ -24,8 +24,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106536&client_id=FH-Bielefeld"
     name: "Quiz Singleton-Pattern (ILIAS)"
-assignments:
-  - topic: sheet06
 youtube:
   - link: "https://youtu.be/ZT3rl1t85aY"
     name: "VL Singleton-Pattern"

--- a/markdown/pattern/strategy.md
+++ b/markdown/pattern/strategy.md
@@ -32,8 +32,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106537&client_id=FH-Bielefeld"
     name: "Quiz Strategy-Pattern (ILIAS)"
-assignments:
-  - topic: sheet03
 youtube:
   - link: "https://youtu.be/WI2riW7yOSE"
     name: "VL Strategy-Pattern"

--- a/markdown/pattern/template-method.md
+++ b/markdown/pattern/template-method.md
@@ -28,8 +28,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106538&client_id=FH-Bielefeld"
     name: "Quiz Template-Method-Pattern (ILIAS)"
-assignments:
-  - topic: sheet07
 youtube:
   - link: "https://youtu.be/EE-n2T6AO-g"
     name: "VL Template-Method-Pattern"

--- a/markdown/pattern/type-object.md
+++ b/markdown/pattern/type-object.md
@@ -33,8 +33,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106539&client_id=FH-Bielefeld"
     name: "Quiz Type-Object-Pattern (ILIAS)"
-assignments:
-  - topic: sheet06
 youtube:
   - link: "https://youtu.be/No-xduTVlt0"
     name: "VL Type-Object-Pattern"

--- a/markdown/pattern/visitor.md
+++ b/markdown/pattern/visitor.md
@@ -49,8 +49,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106543&client_id=FH-Bielefeld"
     name: "Quiz Visitor-Pattern (ILIAS)"
-assignments:
-  - topic: sheet09
 youtube:
   - link: "https://youtu.be/zW_2oQmjp8M"
     name: "VL Visitor-Pattern"

--- a/markdown/testing/junit-basics.md
+++ b/markdown/testing/junit-basics.md
@@ -32,8 +32,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106545&client_id=FH-Bielefeld"
     name: "Quiz JUnit-Basics (ILIAS)"
-assignments:
-  - topic: sheet04
 youtube:
   - link: "https://youtu.be/2SC40rO0ZOE"
     name: "VL JUnit Basics"

--- a/markdown/testing/mockito.md
+++ b/markdown/testing/mockito.md
@@ -28,8 +28,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106547&client_id=FH-Bielefeld"
     name: "Quiz Mocking (ILIAS)"
-assignments:
-  - topic: sheet05
 youtube:
   - link: "https://youtu.be/8deFZKtjXSk"
     name: "VL Mocking"

--- a/markdown/testing/testcases.md
+++ b/markdown/testing/testcases.md
@@ -40,8 +40,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106546&client_id=FH-Bielefeld"
     name: "Quiz Testfallermittlung (ILIAS)"
-assignments:
-  - topic: sheet04
 youtube:
   - link: "https://youtu.be/AR1WWt4AFqI"
     name: "VL Testfallermittlung"

--- a/markdown/testing/testing-intro.md
+++ b/markdown/testing/testing-intro.md
@@ -37,8 +37,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106545&client_id=FH-Bielefeld"
     name: "Quiz JUnit-Basics - nur erster Teil (ILIAS)"
-assignments:
-  - topic: sheet04
 youtube:
   - link: "https://youtu.be/WGd83crqu4I"
     name: "VL Einführung Softwaretest"

--- a/markdown/threads/highlevel.md
+++ b/markdown/threads/highlevel.md
@@ -35,8 +35,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106531&client_id=FH-Bielefeld"
     name: "Quiz High-Level Concurrency (ILIAS)"
-assignments:
-  - topic: sheet10
 youtube:
   - link: "https://youtu.be/bb_kuuhXC6A"
     name: "VL High-Level Concurrency"

--- a/markdown/threads/intro.md
+++ b/markdown/threads/intro.md
@@ -51,8 +51,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106529&client_id=FH-Bielefeld"
     name: "Quiz Threads Intro (ILIAS)"
-assignments:
-  - topic: sheet10
 youtube:
   - link: "https://youtu.be/ClfXbNPRl_8"
     name: "VL Threads Intro"

--- a/markdown/threads/synchronisation.md
+++ b/markdown/threads/synchronisation.md
@@ -50,8 +50,6 @@ outcomes:
 quizzes:
   - link: "https://www.fh-bielefeld.de/elearning/goto.php?target=tst_1106530&client_id=FH-Bielefeld"
     name: "Quiz Threads Synchronisation (ILIAS)"
-assignments:
-  - topic: sheet10
 youtube:
   - link: "https://youtu.be/FtVaobn4NqA"
     name: "VL Threads Synchronisation"


### PR DESCRIPTION
Entferne in allen Vorlesungsbausteinen im YAML den Teil `assignments:`: Die Übungsblätter sind aktuell nicht mehr den Vorlesungen zugeordnet, d.h. der Verweis ist aktuell sinnlos.

fixes #688 