### PR TITLE
[Org] Ergänze Abgabe-Artefakte: PDF, ZIP, Link

### DIFF
--- a/markdown/_index.md
+++ b/markdown/_index.md
@@ -84,7 +84,7 @@ Weitere empfohlene Literatur siehe `["Ressourcen"]({{< ref "/org/resources" >}})
 
 `{{< schedule >}}`{=markdown}
 
-**Hinweise**: Abgabe der Hausaufgaben jeweils bis zur angegebenen Deadline im ILIAS.
+**Hinweise**: Abgabe der Hausaufgaben (PDF, ZIP, Link) jeweils bis zur angegebenen Deadline im ILIAS.
 Peer-Feedback jeweils bis zur angegebenen Deadline im ILIAS.
 Vorstellung der Lösungen im jeweiligen nachfolgenden Praktikumstermin.
 

--- a/markdown/assignments/_index.md
+++ b/markdown/assignments/_index.md
@@ -67,11 +67,12 @@ Anregungen für **Spielideen** können Sie beispielsweise in den folgenden Video
 | [10P Bounty](https://github.com/Programmiermethoden/Dungeon/issues?q=is%3Aopen+is%3Aissue+label%3Abounty+-linked%3Apr+label%3A10P) | 10     |
 
 _Hinweis_: Die Liste der Bounty-Aufgaben wird sich dynamisch verändern. Es wird vorkommen,
-dass Aufgaben im Laufe des Semesters nicht mehr zur Verfügung stehen. Ebenso können im
-Laufe des Semesters neue Aufgaben hinzu kommen. Nicht mehr angebotene Aufgaben können Sie
-nicht mehr zur Bearbeitung wählen.
+dass Aufgaben im Laufe des Semesters nicht mehr zur Verfügung stehen. Ebenso können im Laufe
+des Semesters neue Aufgaben hinzu kommen. Nicht mehr angebotene Aufgaben können Sie nicht
+mehr zur Bearbeitung wählen.
 
-_Hinweis_: Für die Bounty-Aufgaben können Sie zusätzlich bis zu 5 Punkte bekommen, wenn Sie
-Ihre Lösung als [Pull-Request](https://github.com/Programmiermethoden/Dungeon/compare)
-einreichen und Ihr PR vom Dungeon-Team akzeptiert (gemergt) wird. Es kann nur ein PR pro
-Bounty-Aufgabe gemergt werden, die Entscheidung liegt beim Dozenten.
+_Hinweis_: Für die Bounty-Aufgaben können Sie zusätzlich bis zu 3 Bonus-Punkte bekommen, wenn
+Sie Ihre Lösung als [Pull-Request](https://github.com/Programmiermethoden/Dungeon/compare) im
+[Dungeon-Repo](https://github.com/Programmiermethoden/Dungeon) einreichen und Ihr PR vom
+Dungeon-Team akzeptiert (gemergt) wird. Es kann nur ein PR pro Bounty-Aufgabe gemergt werden,
+die Entscheidung liegt beim Dozenten.

--- a/markdown/assignments/b01a.md
+++ b/markdown/assignments/b01a.md
@@ -15,7 +15,7 @@ aus, die Sie in diesem Zyklus bearbeiten wollen, und erstellen Sie dafür ein **
 
 Sie können in diesem Zyklus Aufgaben im Umfang von 15 Punkten abgeben/vorstellen.
 
-Die Konzeptskizze laden Sie bitte bis zur Deadline (s.o.) als PDF in die jeweilige ILIAS-Aufgabe
+Die Konzeptskizze laden Sie bitte bis zur Deadline (s.o.) als **PDF** in die jeweilige ILIAS-Aufgabe
 hoch. **Wichtig**: Diese Abgabe muss aus technischen Gründen bitte **jedes Team-Mitglied einzeln**
 machen.[^2]
 

--- a/markdown/assignments/b01b.md
+++ b/markdown/assignments/b01b.md
@@ -17,7 +17,7 @@ in eine **Implementierung** um.
 
 Den Quellcode und die sonstigen bei der Bearbeitung erstellten Artefakte (Texte,
 Texturen, ..., aber bitte keine `.class`-Dateien) laden Sie bitte bis zur Deadline
-(s.o.) als ZIP in die jeweilige ILIAS-Aufgabe hoch. **Wichtig**: Diese Abgabe muss
+(s.o.) als **ZIP** in die jeweilige ILIAS-Aufgabe hoch. **Wichtig**: Diese Abgabe muss
 aus technischen Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
 
 Anschließend erfolgt eine erneute Peer-Feedback-Phase. ILIAS weist Ihnen wieder

--- a/markdown/assignments/b02a.md
+++ b/markdown/assignments/b02a.md
@@ -15,7 +15,7 @@ aus, die Sie in diesem Zyklus bearbeiten wollen, und erstellen Sie dafür ein **
 
 Sie können in diesem Zyklus Aufgaben im Umfang von 15 Punkten abgeben/vorstellen.
 
-Die Konzeptskizze laden Sie bitte bis zur Deadline (s.o.) als PDF in die jeweilige ILIAS-Aufgabe
+Die Konzeptskizze laden Sie bitte bis zur Deadline (s.o.) als **PDF** in die jeweilige ILIAS-Aufgabe
 hoch. **Wichtig**: Diese Abgabe muss aus technischen Gründen bitte **jedes Team-Mitglied einzeln**
 machen.[^2]
 

--- a/markdown/assignments/b02b.md
+++ b/markdown/assignments/b02b.md
@@ -15,10 +15,14 @@ Setzen Sie gemeinsam im Team Ihr Konzept aus der
 `[ersten Zyklushälfte]({{< ref "/assignments/b02a" >}})`{=markdown}
 in eine **Implementierung** um.
 
-Den Quellcode und die sonstigen bei der Bearbeitung erstellten Artefakte (Texte,
-Texturen, ..., aber bitte keine `.class`-Dateien) laden Sie bitte bis zur Deadline
-(s.o.) als ZIP in die jeweilige ILIAS-Aufgabe hoch. **Wichtig**: Diese Abgabe muss
-aus technischen Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
+Nutzen Sie bei der Umsetzung aktiv Git und einen Git-basierten Workflow für die
+Zusammenarbeit im Team.
+
+Für die Abgabe erstellen Sie einen _öffentlich zugreifbaren_ Pull- oder Merge-Request
+innerhalb Ihres Repos auf Ihrem Git-Server und geben die **URL zu diesem PR/MR** im
+ILIAS als Link ab. Achten Sie bitte darauf, dass der PR/MR nur die für dieses Blatt
+abzugebenden Dateien enthalten darf.[^5]  **Wichtig**: Diese Abgabe muss aus technischen
+Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
 
 Anschließend erfolgt eine erneute Peer-Feedback-Phase. ILIAS weist Ihnen wieder
 mehrere Abgaben zu und Sie haben einen Tag Zeit, um Ihr Feedback im ILIAS abzugeben.
@@ -32,3 +36,4 @@ Auskunft geben.[^4]
 [^2]: vgl. `[Abgabe der Lösungen]({{< ref "/org/faq#abgabe-der-lösungen" >}})`{=markdown} in der FAQ
 [^3]: vgl. `[Peer-Feedback: How to Review]({{< ref "/org/faq#peer-feedback-how-to-review" >}})`{=markdown} in der FAQ
 [^4]: vgl. `[Vorstellung der Lösungen]({{< ref "/org/faq#vorstellung-der-lösungen" >}})`{=markdown} in der FAQ
+[^5]: vgl. `[Link zum Pull-/Merge-Request]({{< ref "/org/faq#link-zum-pull-merge-request" >}})`{=markdown} in der FAQ

--- a/markdown/assignments/b02b.md
+++ b/markdown/assignments/b02b.md
@@ -21,8 +21,9 @@ Zusammenarbeit im Team.
 Für die Abgabe erstellen Sie einen _öffentlich zugreifbaren_ Pull- oder Merge-Request
 innerhalb Ihres Repos auf Ihrem Git-Server und geben die **URL zu diesem PR/MR** im
 ILIAS als Link ab. Achten Sie bitte darauf, dass der PR/MR nur die für dieses Blatt
-abzugebenden Dateien enthalten darf.[^5]  **Wichtig**: Diese Abgabe muss aus technischen
-Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
+abzugebenden Dateien enthält und das der PR/MR bis zur Vorstellung im Praktikum
+**offen** bleibt (nicht vorher gemergt wird).[^5]  **Wichtig**: Diese Abgabe muss aus
+technischen Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
 
 Anschließend erfolgt eine erneute Peer-Feedback-Phase. ILIAS weist Ihnen wieder
 mehrere Abgaben zu und Sie haben einen Tag Zeit, um Ihr Feedback im ILIAS abzugeben.

--- a/markdown/assignments/b03a.md
+++ b/markdown/assignments/b03a.md
@@ -15,7 +15,7 @@ aus, die Sie in diesem Zyklus bearbeiten wollen, und erstellen Sie dafür ein **
 
 Sie können in diesem Zyklus Aufgaben im Umfang von 15 Punkten abgeben/vorstellen.
 
-Die Konzeptskizze laden Sie bitte bis zur Deadline (s.o.) als PDF in die jeweilige ILIAS-Aufgabe
+Die Konzeptskizze laden Sie bitte bis zur Deadline (s.o.) als **PDF** in die jeweilige ILIAS-Aufgabe
 hoch. **Wichtig**: Diese Abgabe muss aus technischen Gründen bitte **jedes Team-Mitglied einzeln**
 machen.[^2]
 

--- a/markdown/assignments/b03b.md
+++ b/markdown/assignments/b03b.md
@@ -22,10 +22,14 @@ Zusätzlich bekommen Sie _bis_ zu 5 Punkte für die Einhaltung einfacher Coding-
 -   Durchgängige Dokumentation mit Javadoc: +2P
 -   Durchgängiger Einsatz von Logging: +1P
 
-Den Quellcode und die sonstigen bei der Bearbeitung erstellten Artefakte (Texte,
-Texturen, ..., aber bitte keine `.class`-Dateien) laden Sie bitte bis zur Deadline
-(s.o.) als ZIP in die jeweilige ILIAS-Aufgabe hoch. **Wichtig**: Diese Abgabe muss
-aus technischen Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
+Nutzen Sie bei der Umsetzung aktiv Git und einen Git-basierten Workflow für die
+Zusammenarbeit im Team.
+
+Für die Abgabe erstellen Sie einen _öffentlich zugreifbaren_ Pull- oder Merge-Request
+innerhalb Ihres Repos auf Ihrem Git-Server und geben die **URL zu diesem PR/MR** im
+ILIAS als Link ab. Achten Sie bitte darauf, dass der PR/MR nur die für dieses Blatt
+abzugebenden Dateien enthalten darf.[^5]  **Wichtig**: Diese Abgabe muss aus technischen
+Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
 
 Anschließend erfolgt eine erneute Peer-Feedback-Phase. ILIAS weist Ihnen wieder
 mehrere Abgaben zu und Sie haben einen Tag Zeit, um Ihr Feedback im ILIAS abzugeben.
@@ -39,3 +43,4 @@ Auskunft geben.[^4]
 [^2]: vgl. `[Abgabe der Lösungen]({{< ref "/org/faq#abgabe-der-lösungen" >}})`{=markdown} in der FAQ
 [^3]: vgl. `[Peer-Feedback: How to Review]({{< ref "/org/faq#peer-feedback-how-to-review" >}})`{=markdown} in der FAQ
 [^4]: vgl. `[Vorstellung der Lösungen]({{< ref "/org/faq#vorstellung-der-lösungen" >}})`{=markdown} in der FAQ
+[^5]: vgl. `[Link zum Pull-/Merge-Request]({{< ref "/org/faq#link-zum-pull-merge-request" >}})`{=markdown} in der FAQ

--- a/markdown/assignments/b03b.md
+++ b/markdown/assignments/b03b.md
@@ -28,8 +28,9 @@ Zusammenarbeit im Team.
 Für die Abgabe erstellen Sie einen _öffentlich zugreifbaren_ Pull- oder Merge-Request
 innerhalb Ihres Repos auf Ihrem Git-Server und geben die **URL zu diesem PR/MR** im
 ILIAS als Link ab. Achten Sie bitte darauf, dass der PR/MR nur die für dieses Blatt
-abzugebenden Dateien enthalten darf.[^5]  **Wichtig**: Diese Abgabe muss aus technischen
-Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
+abzugebenden Dateien enthält und das der PR/MR bis zur Vorstellung im Praktikum
+**offen** bleibt (nicht vorher gemergt wird).[^5]  **Wichtig**: Diese Abgabe muss aus
+technischen Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
 
 Anschließend erfolgt eine erneute Peer-Feedback-Phase. ILIAS weist Ihnen wieder
 mehrere Abgaben zu und Sie haben einen Tag Zeit, um Ihr Feedback im ILIAS abzugeben.

--- a/markdown/assignments/b04a.md
+++ b/markdown/assignments/b04a.md
@@ -15,7 +15,7 @@ aus, die Sie in diesem Zyklus bearbeiten wollen, und erstellen Sie dafür ein **
 
 Sie können in diesem Zyklus Aufgaben im Umfang von 15 Punkten abgeben/vorstellen.
 
-Die Konzeptskizze laden Sie bitte bis zur Deadline (s.o.) als PDF in die jeweilige ILIAS-Aufgabe
+Die Konzeptskizze laden Sie bitte bis zur Deadline (s.o.) als **PDF** in die jeweilige ILIAS-Aufgabe
 hoch. **Wichtig**: Diese Abgabe muss aus technischen Gründen bitte **jedes Team-Mitglied einzeln**
 machen.[^2]
 

--- a/markdown/assignments/b04b.md
+++ b/markdown/assignments/b04b.md
@@ -22,10 +22,14 @@ Zusätzlich bekommen Sie _bis_ zu 5 Punkte für die Einhaltung einfacher Coding-
 -   Durchgängige Dokumentation mit Javadoc: +2P
 -   Durchgängiger Einsatz von Logging: +1P
 
-Den Quellcode und die sonstigen bei der Bearbeitung erstellten Artefakte (Texte,
-Texturen, ..., aber bitte keine `.class`-Dateien) laden Sie bitte bis zur Deadline
-(s.o.) als ZIP in die jeweilige ILIAS-Aufgabe hoch. **Wichtig**: Diese Abgabe muss
-aus technischen Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
+Nutzen Sie bei der Umsetzung aktiv Git und einen Git-basierten Workflow für die
+Zusammenarbeit im Team.
+
+Für die Abgabe erstellen Sie einen _öffentlich zugreifbaren_ Pull- oder Merge-Request
+innerhalb Ihres Repos auf Ihrem Git-Server und geben die **URL zu diesem PR/MR** im
+ILIAS als Link ab. Achten Sie bitte darauf, dass der PR/MR nur die für dieses Blatt
+abzugebenden Dateien enthalten darf.[^5]  **Wichtig**: Diese Abgabe muss aus technischen
+Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
 
 Anschließend erfolgt eine erneute Peer-Feedback-Phase. ILIAS weist Ihnen wieder
 mehrere Abgaben zu und Sie haben einen Tag Zeit, um Ihr Feedback im ILIAS abzugeben.
@@ -39,3 +43,4 @@ Auskunft geben.[^4]
 [^2]: vgl. `[Abgabe der Lösungen]({{< ref "/org/faq#abgabe-der-lösungen" >}})`{=markdown} in der FAQ
 [^3]: vgl. `[Peer-Feedback: How to Review]({{< ref "/org/faq#peer-feedback-how-to-review" >}})`{=markdown} in der FAQ
 [^4]: vgl. `[Vorstellung der Lösungen]({{< ref "/org/faq#vorstellung-der-lösungen" >}})`{=markdown} in der FAQ
+[^5]: vgl. `[Link zum Pull-/Merge-Request]({{< ref "/org/faq#link-zum-pull-merge-request" >}})`{=markdown} in der FAQ

--- a/markdown/assignments/b04b.md
+++ b/markdown/assignments/b04b.md
@@ -28,8 +28,9 @@ Zusammenarbeit im Team.
 Für die Abgabe erstellen Sie einen _öffentlich zugreifbaren_ Pull- oder Merge-Request
 innerhalb Ihres Repos auf Ihrem Git-Server und geben die **URL zu diesem PR/MR** im
 ILIAS als Link ab. Achten Sie bitte darauf, dass der PR/MR nur die für dieses Blatt
-abzugebenden Dateien enthalten darf.[^5]  **Wichtig**: Diese Abgabe muss aus technischen
-Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
+abzugebenden Dateien enthält und das der PR/MR bis zur Vorstellung im Praktikum
+**offen** bleibt (nicht vorher gemergt wird).[^5]  **Wichtig**: Diese Abgabe muss aus
+technischen Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
 
 Anschließend erfolgt eine erneute Peer-Feedback-Phase. ILIAS weist Ihnen wieder
 mehrere Abgaben zu und Sie haben einen Tag Zeit, um Ihr Feedback im ILIAS abzugeben.

--- a/markdown/assignments/b05a.md
+++ b/markdown/assignments/b05a.md
@@ -15,7 +15,7 @@ aus, die Sie in diesem Zyklus bearbeiten wollen, und erstellen Sie dafür ein **
 
 Sie können in diesem Zyklus Aufgaben im Umfang von 15 Punkten abgeben/vorstellen.
 
-Die Konzeptskizze laden Sie bitte bis zur Deadline (s.o.) als PDF in die jeweilige ILIAS-Aufgabe
+Die Konzeptskizze laden Sie bitte bis zur Deadline (s.o.) als **PDF** in die jeweilige ILIAS-Aufgabe
 hoch. **Wichtig**: Diese Abgabe muss aus technischen Gründen bitte **jedes Team-Mitglied einzeln**
 machen.[^2]
 

--- a/markdown/assignments/b05b.md
+++ b/markdown/assignments/b05b.md
@@ -22,10 +22,14 @@ Zusätzlich bekommen Sie _bis_ zu 5 Punkte für die Einhaltung einfacher Coding-
 -   Durchgängige Dokumentation mit Javadoc: +2P
 -   Durchgängiger Einsatz von Logging: +1P
 
-Den Quellcode und die sonstigen bei der Bearbeitung erstellten Artefakte (Texte,
-Texturen, ..., aber bitte keine `.class`-Dateien) laden Sie bitte bis zur Deadline
-(s.o.) als ZIP in die jeweilige ILIAS-Aufgabe hoch. **Wichtig**: Diese Abgabe muss
-aus technischen Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
+Nutzen Sie bei der Umsetzung aktiv Git und einen Git-basierten Workflow für die
+Zusammenarbeit im Team.
+
+Für die Abgabe erstellen Sie einen _öffentlich zugreifbaren_ Pull- oder Merge-Request
+innerhalb Ihres Repos auf Ihrem Git-Server und geben die **URL zu diesem PR/MR** im
+ILIAS als Link ab. Achten Sie bitte darauf, dass der PR/MR nur die für dieses Blatt
+abzugebenden Dateien enthalten darf.[^5]  **Wichtig**: Diese Abgabe muss aus technischen
+Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
 
 Anschließend erfolgt eine erneute Peer-Feedback-Phase. ILIAS weist Ihnen wieder
 mehrere Abgaben zu und Sie haben einen Tag Zeit, um Ihr Feedback im ILIAS abzugeben.
@@ -39,3 +43,4 @@ Auskunft geben.[^4]
 [^2]: vgl. `[Abgabe der Lösungen]({{< ref "/org/faq#abgabe-der-lösungen" >}})`{=markdown} in der FAQ
 [^3]: vgl. `[Peer-Feedback: How to Review]({{< ref "/org/faq#peer-feedback-how-to-review" >}})`{=markdown} in der FAQ
 [^4]: vgl. `[Vorstellung der Lösungen]({{< ref "/org/faq#vorstellung-der-lösungen" >}})`{=markdown} in der FAQ
+[^5]: vgl. `[Link zum Pull-/Merge-Request]({{< ref "/org/faq#link-zum-pull-merge-request" >}})`{=markdown} in der FAQ

--- a/markdown/assignments/b05b.md
+++ b/markdown/assignments/b05b.md
@@ -28,8 +28,9 @@ Zusammenarbeit im Team.
 Für die Abgabe erstellen Sie einen _öffentlich zugreifbaren_ Pull- oder Merge-Request
 innerhalb Ihres Repos auf Ihrem Git-Server und geben die **URL zu diesem PR/MR** im
 ILIAS als Link ab. Achten Sie bitte darauf, dass der PR/MR nur die für dieses Blatt
-abzugebenden Dateien enthalten darf.[^5]  **Wichtig**: Diese Abgabe muss aus technischen
-Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
+abzugebenden Dateien enthält und das der PR/MR bis zur Vorstellung im Praktikum
+**offen** bleibt (nicht vorher gemergt wird).[^5]  **Wichtig**: Diese Abgabe muss aus
+technischen Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
 
 Anschließend erfolgt eine erneute Peer-Feedback-Phase. ILIAS weist Ihnen wieder
 mehrere Abgaben zu und Sie haben einen Tag Zeit, um Ihr Feedback im ILIAS abzugeben.

--- a/markdown/assignments/b06.md
+++ b/markdown/assignments/b06.md
@@ -15,8 +15,7 @@ Dies ist ein Zusatzblatt für Studierende, die bis dahin unterhalb der Bestehens
 für die praktische Teilleistung liegen oder die wegen Krankheit einen Termin nicht
 wahrnehmen konnten.
 
-Für diese Abgabe gibt es keine Konzeptphase und auch kein Peer-Feedback, die Lösung ist
-bis zur Deadline (s.o.) im ILIAS hochzuladen und im nachfolgenden Praktikum vorzustellen.
+Für diese Abgabe gibt es keine Konzeptphase und auch kein Peer-Feedback.
 
 Suchen Sie sich die `[**Aufgaben**]({{< ref "/assignments/" >}})`{=markdown} aus, die Sie
 für diese Abgabe bearbeiten wollen, und **implementieren** dafür Sie Ihre **Lösung**.
@@ -28,13 +27,18 @@ Zusätzlich bekommen Sie _bis_ zu 5 Punkte für die Einhaltung einfacher Coding-
 -   Durchgängige Dokumentation mit Javadoc: +2P
 -   Durchgängiger Einsatz von Logging: +1P
 
-Den Quellcode und die sonstigen bei der Bearbeitung erstellten Artefakte (Texte,
-Texturen, ..., aber bitte keine `.class`-Dateien) laden Sie bitte bis zur Deadline
-(s.o.) als ZIP in die jeweilige ILIAS-Aufgabe hoch. **Wichtig**: Diese Abgabe muss
-aus technischen Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
+Nutzen Sie bei der Umsetzung aktiv Git und einen Git-basierten Workflow für die
+Zusammenarbeit im Team.
+
+Für die Abgabe erstellen Sie einen _öffentlich zugreifbaren_ Pull- oder Merge-Request
+innerhalb Ihres Repos auf Ihrem Git-Server und geben die **URL zu diesem PR/MR** im
+ILIAS als Link ab. Achten Sie bitte darauf, dass der PR/MR nur die für dieses Blatt
+abzugebenden Dateien enthalten darf.[^5]  **Wichtig**: Diese Abgabe muss aus technischen
+Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
 
 Im Praktikum am Freitag in dieser Zyklus-Woche stellen Sie Ihre Implementierung vor.[^4]
 
 
 [^2]: vgl. `[Abgabe der Lösungen]({{< ref "/org/faq#abgabe-der-lösungen" >}})`{=markdown} in der FAQ
 [^4]: vgl. `[Vorstellung der Lösungen]({{< ref "/org/faq#vorstellung-der-lösungen" >}})`{=markdown} in der FAQ
+[^5]: vgl. `[Link zum Pull-/Merge-Request]({{< ref "/org/faq#link-zum-pull-merge-request" >}})`{=markdown} in der FAQ

--- a/markdown/assignments/b06.md
+++ b/markdown/assignments/b06.md
@@ -33,8 +33,9 @@ Zusammenarbeit im Team.
 Für die Abgabe erstellen Sie einen _öffentlich zugreifbaren_ Pull- oder Merge-Request
 innerhalb Ihres Repos auf Ihrem Git-Server und geben die **URL zu diesem PR/MR** im
 ILIAS als Link ab. Achten Sie bitte darauf, dass der PR/MR nur die für dieses Blatt
-abzugebenden Dateien enthalten darf.[^5]  **Wichtig**: Diese Abgabe muss aus technischen
-Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
+abzugebenden Dateien enthält und das der PR/MR bis zur Vorstellung im Praktikum
+**offen** bleibt (nicht vorher gemergt wird).[^5]  **Wichtig**: Diese Abgabe muss aus
+technischen Gründen bitte **jedes Team-Mitglied einzeln** machen.[^2]
 
 Im Praktikum am Freitag in dieser Zyklus-Woche stellen Sie Ihre Implementierung vor.[^4]
 

--- a/markdown/org/faq.md
+++ b/markdown/org/faq.md
@@ -105,9 +105,10 @@ Dabei ist jedes Teammitglied anwesend und kann Auskunft geben.
 ### Zweite Woche: Implementierungsphase
 
 Danach treten Sie in die zweite Woche des aktuellen Zyklus ein und setzen im Team Ihr
-Konzept in eine Implementierung um. Diese laden als ZIP-Datei bis zur Deadline als
-Abgabe in die jeweilige ILIAS-Aufgabe hoch. Diese Abgabe muss aus technischen Gründen
-bitte jedes Teammitglied einzeln machen.
+Konzept in eine Implementierung um. Diese laden als ZIP-Datei bzw. als Link zum öffentlich
+sichtbaren Pull- oder Merge-Request (vgl. Arbeitsanweisungen auf den Aufgabenblättern)
+bis zur Deadline als Abgabe in die jeweilige ILIAS-Aufgabe hoch. Diese Abgabe muss aus
+technischen Gründen bitte jedes Teammitglied einzeln machen.
 
 Anschließend erfolgt eine erneute Peer-Feedback-Phase. ILIAS weist Ihnen mehrere Abgaben
 zu und Sie haben einen Tag Zeit, um Ihr Feedback im ILIAS abzugeben (vgl.
@@ -169,7 +170,7 @@ dem Semester neu aufgesetzt.
 Sie können sich in jedem Zyklus die Aufgaben relativ frei auswählen; natürlich
 hängen aber manche Aufgaben von anderen Aufgaben ab.
 
-Sie können **jede Aufgabe nur einmal bearbeiten und abgeben**.
+Sie können **jede Aufgabe maximal einmal bearbeiten und abgeben**.
 
 Ausnahme: Die "freien Aufgaben" können Sie gern wiederholt bearbeiten, so lange
 Sie jeweils ein Problem wählen, das nicht bereits in anderen Aufgaben vorkommt.
@@ -243,9 +244,10 @@ In der Skizze beschreiben Sie mindestens die folgenden Punkte:
 
 Die Konzeptskizze geben Sie als PDF-Dokument ab (jedes Teammitglied einzeln!).
 
-Zur Orientierung stellen wir Ihnen ein [ausgefülltes Beispiel] zur Verfügung. Bitte beachten
-Sie, dass es in diesem Beispiel um eine fikitive Aufgabe im Dungeon geht und dass die gezeigte
-Modellierung nicht konform zur ECS-Struktur des aktuellen Dungeons ist.
+Zur Orientierung stellen wir Ihnen ein [ausgefülltes Beispiel] als Markdown zur Verfügung.
+Bitte beachten Sie, dass es in diesem Beispiel um eine fikitive Aufgabe im Dungeon geht
+und dass die gezeigte Modellierung nicht konform zur ECS-Struktur des aktuellen PM-Dungeons
+ist.
 
 [ausgefülltes Beispiel]: https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/org/konzeptskizze_beispiel.md
 
@@ -253,11 +255,12 @@ Modellierung nicht konform zur ECS-Struktur des aktuellen Dungeons ist.
 ## Abgabe der Lösungen
 
 Bitte laden Sie Ihre Lösung als eine **PDF-Datei** (Konzeptphase) oder als ein
-**Zip-Archiv** (Implementierungsphase) in die jeweilige Aufgabe im ILIAS hoch.
+**Zip-Archiv** bzw. **Link zum Pull-/Merge-Request** (Implementierungsphase) in
+die jeweilige Aufgabe im ILIAS hoch.
 
 Beachten Sie dabei die jeweilige Deadline.
 
-**Wichtig**: Jedes Teammitglied gibt die Lösung selbst ab (einzeln).
+[**Wichtig**: Jedes Teammitglied gibt die Lösung selbst ab (einzeln).]{.alert}
 
 _Anmerkung_: Falls Sie mehrere Dateien hochladen wollen, erzeugen Sie bitte vor
 dem Upload lokal ein Zip-Archiv, welches Sie dann per Button "Datei einreichen"
@@ -281,7 +284,7 @@ Gehen Sie **nach der Deadline der Aufgabe** und **vor der Deadline des Reviews**
 ILIAS in die Aufgabe und klicken auf den Button "Feedback geben", um nachzuschauen,
 wem Sie ein Peer-Feedback geben sollen.
 
-**Wichtig**: Jedes Teammitglied erstellt seine eigenen Reviews (einzeln).
+[**Wichtig**: Jedes Teammitglied erstellt seine eigenen Reviews (einzeln).]{.alert}
 
 ![](images/howtofeedback2.png){width="80%"}
 

--- a/markdown/org/faq.md
+++ b/markdown/org/faq.md
@@ -123,15 +123,18 @@ Dabei ist jedes Teammitglied anwesend und kann Auskunft geben.
 [Peer-Feedback: How to Review]: #peer-feedback-how-to-review
 
 
-## Bearbeitung der Übungsaufgaben
+## Teams im Praktikum
 
 Die Übungsaufgaben sollen in 3er-Teams bearbeitet und gelöst werden. Die Einteilung
-wird über Etherpads im ILIAS vorgenommen, dabei können Sie die Teams selbst bilden.
+wird über Etherpads im ILIAS vorgenommen, dabei können Sie die Teams selbst bilden
+(siehe auch [Zeitslots für Vorstellung] in der FAQ).
 
 Sie können Ihre Teams gern auch im Semester wechseln, dazu müssen Sie einfach nur den
 Eintrag in den Etherpads im ILIAS anpassen.
 
 In Absprache mit dem Dozenten sind in Ausnahmefällen auch 2er-Teams möglich.
+
+[Zeitslots für Vorstellung]: #zeitslots-für-vorstellung
 
 
 ## Git-Server für die Bearbeitung der Aufgaben
@@ -152,7 +155,7 @@ beispielsweise:
 -   [GitLab.com](https://gitlab.com)
 -   [Bitbucket](https://bitbucket.org)
 
-Wir haben im Software-Labor für die Lehre eine GitLab-Instanz eingerichtet
+Wir haben im Software-Labor für die Lehre eine [GitLab-Instanz] eingerichtet
 ([git03-ifm-min.ad.fh-bielefeld.de]), falls Sie kein kommerzielles System
 nutzen möchten. Unser Server ist nur im FH-Netz bzw. über VPN erreichbar und
 Sie können sich dort mit Ihren FH-Zugangsdaten (LDAP) anmelden. Bitte nutzen
@@ -163,6 +166,7 @@ Angebote. Außerdem wird dieser Server ohne weitere Vorwarnung jeweils nach
 dem Semester neu aufgesetzt.
 
 [git03-ifm-min.ad.fh-bielefeld.de]: http://git03-ifm-min.ad.fh-bielefeld.de
+[GitLab-Instanz]: http://git03-ifm-min.ad.fh-bielefeld.de
 
 
 ## Auswahl der Übungsaufgaben
@@ -279,8 +283,8 @@ die Review-Fragen beantworten.
 ## Abgabe der Lösungen
 
 Bitte laden Sie Ihre Lösung als eine **PDF-Datei** (Konzeptphase) oder als ein
-**Zip-Archiv** bzw. **Link zum Pull-/Merge-Request** (Implementierungsphase) in
-die jeweilige Aufgabe im ILIAS hoch.
+**Zip-Archiv** bzw. **Link zum Pull-/Merge-Request** (Implementierungsphase, vgl.
+Arbeitsanweisungen auf dem Blatt) in die jeweilige Aufgabe im ILIAS hoch.
 
 Beachten Sie dabei die jeweilige Deadline.
 

--- a/markdown/org/faq.md
+++ b/markdown/org/faq.md
@@ -252,6 +252,30 @@ ist.
 [ausgefülltes Beispiel]: https://github.com/Programmiermethoden/PM-Lecture/blob/master/markdown/org/konzeptskizze_beispiel.md
 
 
+## Link zum Pull-/Merge-Request
+
+Bei der Implementierung setzen Sie aktiv Git und einen beliebigen Git-basierten
+Workflow für die Zusammenarbeit im Team ein. Sie haben entsprechend ein Repo auf
+einem Server (vgl. [Git-Server für die Bearbeitung der Aufgaben] in der FAQ),
+welches für die Abgabe öffentlich einsehbar ist.
+
+Für die Abgabe erstellen Sie einen _öffentlich zugreifbaren_ Pull- oder Merge-Request
+innerhalb Ihres Repos auf Ihrem Git-Server und geben nur die **URL zu diesem PR/MR** im
+ILIAS als Link ab.
+
+Achten Sie bitte darauf, dass der PR/MR nur die für dieses Blatt abzugebenden Dateien
+enthalten darf. Dies können Sie beispielsweise erreichen, indem Sie vor der Bearbeitung
+eines Blattes einen entsprechenden Feature-Branch anlegen und die Lösung in diesem Branch
+implementieren. Der PR/MR geht dann von diesem Feature-Branch in den Hauptbranch Ihres
+Repos (oder in den Branch, von dem Sie den Feature-Branch abgezweigt haben).
+
+Im Peer-Feedback können Sie dann einfach über die von den anderen Teams abgegebenen Links
+auf die PR/MR gehen und sich gezielt die geänderten Dateien anschauen und dann im ILIAS
+die Review-Fragen beantworten.
+
+[Git-Server für die Bearbeitung der Aufgaben]: #git-server-für-die-bearbeitung-der-aufgaben
+
+
 ## Abgabe der Lösungen
 
 Bitte laden Sie Ihre Lösung als eine **PDF-Datei** (Konzeptphase) oder als ein

--- a/markdown/org/faq.md
+++ b/markdown/org/faq.md
@@ -273,6 +273,8 @@ eines Blattes einen entsprechenden Feature-Branch anlegen und die Lösung in die
 implementieren. Der PR/MR geht dann von diesem Feature-Branch in den Hauptbranch Ihres
 Repos (oder in den Branch, von dem Sie den Feature-Branch abgezweigt haben).
 
+[Mergen Sie diese PR/MR erst _nach_ der Vorstellung im Praktikum!]{.alert}
+
 Im Peer-Feedback können Sie dann einfach über die von den anderen Teams abgegebenen Links
 auf die PR/MR gehen und sich gezielt die geänderten Dateien anschauen und dann im ILIAS
 die Review-Fragen beantworten.

--- a/markdown/org/faq.md
+++ b/markdown/org/faq.md
@@ -265,7 +265,8 @@ welches für die Abgabe öffentlich einsehbar ist.
 
 Für die Abgabe erstellen Sie einen _öffentlich zugreifbaren_ Pull- oder Merge-Request
 innerhalb Ihres Repos auf Ihrem Git-Server und geben nur die **URL zu diesem PR/MR** im
-ILIAS als Link ab.
+ILIAS als Link ab. Lassen Sie diesen PR/MR bitte so lange offen, bis die Vorstellung im
+Praktikum erfolgt ist. Danach können Sie den PR/MR ganz nach Belieben mergen oder schließen.
 
 Achten Sie bitte darauf, dass der PR/MR nur die für dieses Blatt abzugebenden Dateien
 enthalten darf. Dies können Sie beispielsweise erreichen, indem Sie vor der Bearbeitung

--- a/markdown/org/grading.md
+++ b/markdown/org/grading.md
@@ -14,7 +14,7 @@ hidden: true
 
 -   **Praktische Teilleistung**:
     Regelmäßige Bearbeitung der Praktikumsaufgaben,
-    fristgerechte Abgabe der Lösungen im ILIAS,
+    fristgerechte Abgabe der Lösungen (PDF, ZIP, Link) im ILIAS,
     Erstellung von Peer-Feedback im ILIAS,
     Vorstellung der Lösungen im Praktikum => Punkte
 
@@ -55,7 +55,7 @@ Das Praktikum erfolgt in 2-Wochen-Zyklen:
     -   Vorstellung der Konzeptskizze im Praktikum (=> Team)
 2.  Zweite Zyklus-Woche: Implementierungsphase
     -   Umsetzung des Konzepts/Implementierung der Lösung (=> Team)
-    -   Abgabe des Quellcodes (ZIP) im ILIAS (=> Jede(r) einzeln)
+    -   Abgabe des Quellcodes (ZIP bzw. Link) im ILIAS (=> Jede(r) einzeln)
     -   Peer-Feedback zum Quellcode im ILIAS (=> Jede(r) einzeln)
     -   Vorstellung des Quellcodes im Praktikum (=> Team)
 
@@ -64,14 +64,15 @@ Sie können pro Zyklus Aufgaben im Umfang von 15 Punkten abgeben/vorstellen.
 ### Punktevergabe
 
 Für die Vergabe der Punkte müssen Sie pro Zyklus jeweils fristgerecht
-Ihre Konzeptskizze eingereicht und im Praktikum vorgestellt haben,
+Ihre Konzeptskizze als PDF eingereicht und im Praktikum vorgestellt haben,
 in beiden Zyklen-Hälften das Peer-Feedback erstellt haben und
-die Lösung (Quellcode) eingereicht und im Praktikum vorgestellt haben.
+die Lösung (Quellcode: Abgabe per ZIP oder Link, vgl. Anweisungen auf den
+Übungsblättern) eingereicht und im Praktikum vorgestellt haben.
 
 ### Sonderabgabe letzte Vorlesungswoche
 
 Zusatztermin für Studierende, die bis dahin unterhalb der Bestehensschwelle für die praktische
 Teilleistung liegen oder die wegen Krankheit einen Termin nicht wahrnehmen konnten.
 
-Für diese Abgabe gibt es keine Konzeptphase und auch kein Peer-Feedback, die Lösung ist bis
-zur Deadline im ILIAS hochzuladen und im nachfolgenden Praktikum vorzustellen.
+Für diese Abgabe gibt es keine Konzeptphase und auch kein Peer-Feedback, die Lösung (Link)
+ist bis zur Deadline im ILIAS hochzuladen und im nachfolgenden Praktikum vorzustellen.


### PR DESCRIPTION
Ab Zyklus 2 (also Zyklen 2..5 plus Sonderabgabe) sollen die Implementierungen nicht mehr als Zip-File im ILIAS hochgeladen werden. Stattdessen sollen sich die Studis auf einem System ihrer Wahl (GitHub, GitLab, Bitbucket, Git03(!)) ein öffentliches Repo einrichten und die zur Abgabe vorgesehenen Dateien in einem Pull-/Merge-Request zusammensammeln. Den Link zu diesem PR/MR sollen sie im ILIAS abgeben.


Anpassen:

- [x] Landing-Page (Hinweis unter dem Schedule)
- [x] Grading
- [x] FAQ
- [x] Landing-Page Praktikum: Anzahl Bonuspunkte (3 statt 5), Link in die FAQ
- [x] Übungsblätter: Genaue Abgabehinweise auf dem Blatt (nicht nur das Datum)


fixes #694 