### PR TITLE
[Tool] Ergänze .editorconfig für Windows- und YAML-Dateien

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,5 +21,3 @@ end_of_line = crlf
 [*.{hs,yaml}]
 indent_style = space
 indent_size = 2
-
-blablablab

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,9 @@ insert_final_newline = true
 
 [Makefile]
 indent_style = tab
+
+[{*.sh, gradlew}]
+end_of_line = lf
+
+[{*.bat, *.cmd}]
+end_of_line = crlf

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,6 @@ end_of_line = lf
 [{*.bat, *.cmd}]
 end_of_line = crlf
 
-[*.{hs,yaml}]
+[{*.hs, *.yaml}]
 indent_style = space
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -21,3 +21,5 @@ end_of_line = crlf
 [*.{hs,yaml}]
 indent_style = space
 indent_size = 2
+
+blablablab

--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,7 @@ end_of_line = lf
 
 [{*.bat, *.cmd}]
 end_of_line = crlf
+
+[*.{hs,yaml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
- Nutze für Windows-Dateien statt `lf` ein `crlf` als Zeilenende
- In YAML-Dateien rücke nur 2 Spaces ein (statt 4)