### PR TITLE
[ORCA.nrw] Fix some non-functional buttons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,8 +184,8 @@ SLIDES_SHORT_TARGETS           = $(patsubst $(SLIDES_OUTPUT_DIR)/%.pdf,%,$(SLIDE
 help:  ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-.PHONY: list-slides
-list-slides: ## List available targets for individual slides
+.PHONY: list_slides
+list_slides: ## List available targets for individual slides
 	$(foreach target,$(SLIDES_SHORT_TARGETS), $(info $(target)))
 	@: ## Suppress 'Nothing to be done for ...' message
 

--- a/markdown/building/docker.md
+++ b/markdown/building/docker.md
@@ -228,7 +228,7 @@ im Container geschrieben und erscheint dann im Arbeitsverzeichnis auf dem Host .
 dann mit `java Hello` die Klasse ausgeführt werden.
 :::
 
-[Demo: Container in der Konsole]{.bsp}
+[Demo: Container in der Konsole]{.bsp href="https://youtu.be/LE_QcHqUg9Y"}
 
 
 ## Images selbst definieren
@@ -323,7 +323,7 @@ Containers gesendet. Im Prinzip entspricht das dem Aufruf auf dem lokalen Rechne
 `docker run openjdk:17 javac Hello.java`.
 :::
 
-[Demo: GitLab CI/CD und Docker]{.bsp}
+[Demo: GitLab CI/CD und Docker]{.bsp href="https://youtu.be/3Tj3lhcoKro"}
 
 
 ## CI-Pipeline (GitHub)
@@ -359,7 +359,7 @@ Ubuntu-Runner als Container ausgeführt. Die Aktionen im `steps`-Teil, wie beisp
 Im Prinzip entspricht das dem Aufruf auf dem lokalen Rechner: `docker run openjdk:17 javac Hello.java`.
 :::
 
-[Demo: GitHub Actions und Docker]{.bsp}
+[Demo: GitHub Actions und Docker]{.bsp href="https://youtu.be/jrxoax2fPRI"}
 
 
 ## VSCode und das Plugin "Remote - Containers"
@@ -405,7 +405,7 @@ Auf diesem Konzept setzt auch der kommerzielle Service [GitHub Codespaces](https
 von GitHub auf.
 :::
 
-[Demo: VSCode und Docker]{.bsp}
+[Demo: VSCode und Docker]{.bsp href="https://youtu.be/Rs1W_rXkoNM"}
 
 
 ::::::::: notes

--- a/markdown/coding/codingrules.md
+++ b/markdown/coding/codingrules.md
@@ -411,7 +411,7 @@ Properties und deren Default-Einstellungen.
 Alternativen/Ergänzungen: beispielsweise [MetricsReloaded](https://github.com/BasLeijdekkers/MetricsReloaded).
 :::
 
-[Demo: Konfiguration mit Eclipse-CS, Hinweis auf Formatter]{.bsp}
+[Demo: Konfiguration mit Eclipse-CS, Hinweis auf Formatter]{.bsp href="https://youtu.be/0ny6e6CNTF8"}
 
 
 ## SpotBugs: Finde Anti-Pattern und potentielle Bugs (Linter)

--- a/markdown/coding/tdd.md
+++ b/markdown/coding/tdd.md
@@ -211,7 +211,7 @@ public void ausgabe(...) {
 _Anmerkung_: Jeder Zyklus sollte sehr kurz sein!
 [=> Pro Stunde schafft man i.d.R. viele Rot/Grün/Refactoring-Zyklen!]{.notes}
 
-[Demo: Validierung von Passwörtern]{.bsp}
+[Demo: Validierung von Passwörtern]{.bsp href="https://youtu.be/4NAcu8I8fJk"}
 
 ::: notes
 ### Vorteile bei konsequenter Anwendung von TDD

--- a/markdown/generics/generics-polymorphism.md
+++ b/markdown/generics/generics-polymorphism.md
@@ -123,7 +123,7 @@ String[] y = x;  // String[] ist KEIN Object[]!!!
 *   Arrays besitzen Typinformationen über gespeicherte Elemente
 *   Prüfung auf Typ-Kompatibilität zur **Laufzeit** (nicht Kompilierzeit!)
 
-[Hinweis auf Java-Geschichte]{.bsp}
+[Hinweis auf Java-Geschichte [(Java-Insel: "Type Erasure")]{.notes}]{.bsp href="https://openbook.rheinwerk-verlag.de/javainsel/11_002.html#u11.2.2"}
 
 ::: notes
 Arrays gab es sehr früh, Generics erst relativ spät (ab Java6) => bei

--- a/markdown/git/bisect.md
+++ b/markdown/git/bisect.md
@@ -83,7 +83,7 @@ fhmedia:
 
 3.  Workingcopy zurücksetzen: `git bisect reset`
 
-[Live-Demo]{.bsp}
+[Live-Demo]{.bsp href="https://youtu.be/hiiugrQMNR4"}
 
 
 ::::::::: notes

--- a/markdown/git/branches.md
+++ b/markdown/git/branches.md
@@ -360,7 +360,7 @@ Manuelles Editieren nötig (Auflösung des Konflikts):
 Alternativ: Nutzung graphischer Oberflächen mittels `git mergetool`
 :::
 
-[Konsole: Branchen und Mergen]{.bsp}
+[Konsole: Branchen und Mergen]{.bsp href="https://youtu.be/B8sesK1GyiE"}
 
 
 ## Rebasen: Verschieben von Branches
@@ -449,7 +449,7 @@ und Message bleiben aber erhalten.)
         "kopflosen" Commits irgendwann tatsächlich verschwinden.
         :::
 
-[Konsole: Commit auschecken]{.bsp}
+[[Konsole: Commit auschecken]{.bsp}]{.slides}
 
 
 ## Wrap-Up

--- a/markdown/git/remotes.md
+++ b/markdown/git/remotes.md
@@ -249,7 +249,7 @@ Zwischenzeit weiter geschoben - dann muss die Aktualisierung erneut durchgeführ
 werden).
 :::::::::
 
-[Beispiel für Zusammenführen (merge und push), Anmerkung zu fast forward merge]{.bsp}
+[Beispiel für Zusammenführen (merge und push), Anmerkung zu fast forward merge]{.bsp href="https://youtu.be/moqywsxtEy8"}
 
 
 ## Branches und Remotes
@@ -264,7 +264,7 @@ werden).
     *   Lokale Änderungen an remote Branches nicht möglich! \newline
         => **Remote Branch in lokalen Branch mergen** (oder auschecken)
 
-[Beispiel]{.bsp}
+[[Beispiel]{.bsp}]{.slides}
 
 
 ## Zusammenfassung: Arbeiten mit Remotes

--- a/markdown/java-jvm/configuration.md
+++ b/markdown/java-jvm/configuration.md
@@ -90,7 +90,7 @@ man kann prinzipiell auch in der Kurzform das "=" nutzen, also "-x=10", oder in 
 mit einem Leerzeichen trennen, also "--breite 10".
 :::
 
-[Demo IDE und CLI]{.bsp}
+[Demo IDE und CLI]{.bsp href="https://youtu.be/a3XUfDbD9uo"}
 
 ::: notes
 Hinweis IntelliJ: "`Edit Configurations`" => Kommandozeilenparameter unter "`Build and run`" im entsprechenden Feld eintragen


### PR DESCRIPTION
Ich verwende Buttons als Hinweis auf eine Aktion, die ich in der Vorlesung oder im Video durchführen möchte. In der Regel sind das Code-Beispiele, weshalb dann die "Buttons" im Skript mit einem Link auf Github und den Quellcode verlinkt sind. Jetzt gibt es aber auch Buttons, die mich einfach nur an eine Demo in der Konsole o.ä. erinnern sollen. Dem ORCA-Team ist bei der Durchsicht aufgestoßen, dass sie einzelne solcher Buttons nicht "drücken" konnten.

Diese PR behebt das "Problem" und ordnet den meisten dieser Demo-Buttons das entsprechende Demo-Video zu. Falls das nicht möglich war, wurde der Button im Skript unsichtbar geschaltet (ist also nur im Foliensatz vorhanden).