### PR TITLE
Tool: switch to 'default' layout for chapter landing pages

### DIFF
--- a/markdown/assignments/_index.md
+++ b/markdown/assignments/_index.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Praktikum"
 weight: 0
 

--- a/markdown/assignments/group_basics/_index.md
+++ b/markdown/assignments/group_basics/_index.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Praktikumsaufgaben Gruppe Basics"
 weight: 1
 

--- a/markdown/assignments/group_loot/_index.md
+++ b/markdown/assignments/group_loot/_index.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Praktikumsaufgaben Gruppe Loot"
 weight: 3
 

--- a/markdown/assignments/group_monster/_index.md
+++ b/markdown/assignments/group_monster/_index.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Praktikumsaufgaben Gruppe Monster"
 weight: 2
 

--- a/markdown/building/_index.md
+++ b/markdown/building/_index.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Bauen von Programmen, Automatisierung, Continuous Integration"
 menuTitle: "Building"
 weight: 4

--- a/markdown/coding/_index.md
+++ b/markdown/coding/_index.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Programmiermethoden und Clean Code"
 menuTitle: "Coding"
 weight: 3

--- a/markdown/database/_index.md
+++ b/markdown/database/_index.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Zugriffe auf Datenbanken: JDBC"
 menuTitle: "Database"
 weight: 12

--- a/markdown/frameworks/_index.md
+++ b/markdown/frameworks/_index.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Umgang mit Frameworks"
 menuTitle: "Frameworks"
 weight: 11

--- a/markdown/generics/_index.md
+++ b/markdown/generics/_index.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Generics: Umgang mit parametrisierten Typen"
 menuTitle: "Generics"
 weight: 6

--- a/markdown/git/_index.md
+++ b/markdown/git/_index.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Versionierung mit Git"
 menuTitle: "Git"
 weight: 1

--- a/markdown/gui/_index.md
+++ b/markdown/gui/_index.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Graphische Oberflächen mit Swing und Java2D"
 menuTitle: "GUI"
 weight: 10

--- a/markdown/java-jvm/_index.md
+++ b/markdown/java-jvm/_index.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Fortgeschrittene Java-Themen und Umgang mit JVM"
 menuTitle: "Java / JVM"
 weight: 7

--- a/markdown/modern-java/_index.md
+++ b/markdown/modern-java/_index.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Modern Java: Funktionaler Stil und Stream-API"
 menuTitle: "Modern Java"
 weight: 8

--- a/markdown/org/_index.md
+++ b/markdown/org/_index.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Organisatorisches"
 weight: 0
 

--- a/markdown/pattern/_index.md
+++ b/markdown/pattern/_index.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Entwurfsmuster"
 menuTitle: "Pattern"
 weight: 5

--- a/markdown/testing/_index.md
+++ b/markdown/testing/_index.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Testen mit JUnit und Mockito"
 menuTitle: "Testing"
 weight: 2

--- a/markdown/threads/_index.md
+++ b/markdown/threads/_index.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Multi-Threading: Parallelisierung von Programmen"
 menuTitle: "Threads"
 weight: 9


### PR DESCRIPTION
Das `chapter`-Template ist irgendwie kaputt: Die Fußzeile wird viel zu groß dargestellt. Das betrifft auch das originale `chapter`-Template ... Wir wechseln hier auf das `default`-Template, wodurch die Fußzeile wieder passt. Einzig der `<hr>` unter dem Titel fehlt ...