### PR TITLE
Readme: remove links to different preview variants

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,16 +23,6 @@ attachments:
   [daringfireball.net]: https://daringfireball.net/2020/04/cobol_programming_coding
 
 
-::: tip
-**Vorschau**
-
-Sie können die Vorlesungsunterlagen in zwei Varianten anschauen:
-
-*   [Markdown in GitHub](https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/_gfm/readme.md)
-*   [Docsify (experimentell)](https://docsify-this.net/?basePath=https://raw.githubusercontent.com/Programmiermethoden-CampusMinden/Prog2-Lecture/refs/heads/_docsify&homepage=readme.md&sidebar=true&browser-tab-title=PR2&font-size=14px&searchbox=true&externalLinkTarget=_blank&mergeNavbar=true&zoom-images=true&dark-mode=auto#/)
-:::
-
-
 # Kursbeschreibung
 
 Sie haben letztes Semester in **Prog1** die *wichtigsten* Elemente und Konzepte der


### PR DESCRIPTION
The links to the different preview variants are no longer needed in the readme, as they are provided in different places:

1. The GFM variant is set as 'default' in the repo
2. There is a link to the Docsify version in the repo
3. Direct links to both variants are provided in ILIAS

This section has been removed to improve readability.